### PR TITLE
Expose memory reads/writes to the IDE

### DIFF
--- a/IDE/backend/c_dtypes.py
+++ b/IDE/backend/c_dtypes.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 class c_style_int:
     def __init__(self, value):
         """Initialize the integer value. This method should be overridden in derived classes for sign handling."""
@@ -162,3 +164,14 @@ def convert_to_hex(value):
         return f"0x{value.__value:016x}"
 
     return f"0x{value:016x}"
+
+@dataclass
+class MemRead:
+    addr:  str # address of the read (hex)
+    value: str # value (hex)
+
+@dataclass
+class MemWrite:
+    addr:  str # address of the write (hex)
+    value: str # value (hex)
+    prior: str # prior value (hex)

--- a/IDE/backend/state_db.py
+++ b/IDE/backend/state_db.py
@@ -59,6 +59,22 @@ class StateDB:
         cmd = cmd.format(inst_uid, dquote(elem_name), dquote(elem_val), dquote(expected_elem_val))
         self.cursor.execute(cmd)
 
+    def AppendMemAccesses(self, inst_uid, mem_reads, mem_writes):
+        for read in mem_reads:
+            mem_addr = read.addr
+            mem_value = read.value
+            cmd = 'INSERT INTO MemoryAccesses (InstUID, Addr, Value) VALUES ({}, {}, {})'
+            cmd = cmd.format(inst_uid, dquote(mem_addr), dquote(mem_value))
+            self.cursor.execute(cmd)
+
+        for write in mem_writes:
+            mem_addr = write.addr
+            mem_prior = write.prior
+            mem_value = write.value
+            cmd = 'INSERT INTO MemoryAccesses (InstUID, Addr, Value, Prior) VALUES ({}, {}, {}, {})'
+            cmd = cmd.format(inst_uid, dquote(mem_addr), dquote(mem_prior), dquote(mem_value))
+            self.cursor.execute(cmd)
+
     def Close(self):
         if self.__conn:
             self.__conn.close()
@@ -108,4 +124,22 @@ class StateDB:
                 ElemVal TEXT,
                 ExpectedElemVal TEXT
             )
+        ''')
+
+        self.cursor.execute('''
+            CREATE TABLE IF NOT EXISTS MemoryAccesses (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                InstUID INTEGER,
+                Addr TEXT,
+                Value TEXT,
+                Prior TEXT DEFAULT 'N/A'
+            )
+        ''')
+
+        self.cursor.execute('''
+            CREATE INDEX IF NOT EXISTS MemoryAccesses_InstUID ON MemoryAccesses (InstUID)
+        ''')
+
+        self.cursor.execute('''
+            CREATE INDEX IF NOT EXISTS Instructions_PC ON Instructions (PC)
         ''')

--- a/IDE/backend/state_serializer.py
+++ b/IDE/backend/state_serializer.py
@@ -61,6 +61,11 @@ class StateSerializer(Observer):
 
                     state_db.AppendRegChange(uid, reg_name, cur_val, expected_val)
 
+            mem_reads = atlas_mem_reads(endpoint)
+            mem_writes = atlas_mem_writes(endpoint)
+            if mem_reads or mem_writes:
+                state_db.AppendMemAccesses(uid, mem_reads, mem_writes)
+
     def OnPreSimulation(self, endpoint):
         for reg_id in range(atlas_num_regs_in_group(endpoint, 0)):
             reg_name = 'x' + str(reg_id)

--- a/IDE/editor/test_debugger.py
+++ b/IDE/editor/test_debugger.py
@@ -211,6 +211,19 @@ class StateViewer(wx.Panel):
             curr_val = FormatHex(curr_val)
             changes_list.append('{}({})'.format(reg_name, '{}->{}'.format(prev_val, curr_val)))
 
+        for mem_read in snapshot.getMemReads():
+            addr = FormatHex(mem_read.addr)
+            value = FormatHex(mem_read.value)
+            change = 'memread.{}({})'.format(addr, value)
+            changes_list.append(change)
+
+        for mem_write in snapshot.getMemWrites():
+            addr = FormatHex(mem_write.addr)
+            value = FormatHex(mem_write.value)
+            prior = FormatHex(mem_write.prior)
+            change = 'memwrite.{}({}->{})'.format(addr, prior, value)
+            changes_list.append(change)
+
         if not changes_list:
             changes_list.append('none')
 

--- a/core/AtlasState.cpp
+++ b/core/AtlasState.cpp
@@ -195,6 +195,13 @@ namespace atlas
         // Set up translation; baremetal for now
         translate_unit_->changeMMUMode(xlen_, mode_);
 
+        if (interactive_mode_)
+        {
+            auto observer = std::make_unique<SimController>();
+            sim_controller_ = observer.get();
+            addObserver(std::move(observer));
+        }
+
         for (auto & obs : observers_)
         {
             obs->registerReadWriteCallbacks(atlas_system_->getSystemMemory());
@@ -704,11 +711,8 @@ namespace atlas
             std::cout << std::dec;
         }
 
-        if (interactive_mode_)
+        if (sim_controller_)
         {
-            auto observer = std::make_unique<SimController>();
-            sim_controller_ = observer.get();
-            addObserver(std::move(observer));
             sim_controller_->postInit(this);
         }
     }

--- a/core/observers/Observer.hpp
+++ b/core/observers/Observer.hpp
@@ -55,15 +55,15 @@ namespace atlas
             return preExecute_(state);
         }
 
-        ActionGroup* postExecute(AtlasState* state) { return postExecute_(state); }
+        ActionGroup* postExecute(AtlasState* state)
+        {
+            return postExecute_(state);
+        }
 
-        ActionGroup* preException(AtlasState* state) { return preException_(state); }
-
-        virtual ActionGroup* preExecute_(AtlasState*) { return nullptr; }
-
-        virtual ActionGroup* postExecute_(AtlasState*) { return nullptr; }
-
-        virtual ActionGroup* preException_(AtlasState*) { return nullptr; }
+        ActionGroup* preException(AtlasState* state)
+        {
+            return preException_(state);
+        }
 
         virtual void stopSim() {}
 
@@ -101,6 +101,13 @@ namespace atlas
         sparta::utils::ValidValue<FaultCause> fault_cause_;
         sparta::utils::ValidValue<InterruptCause> interrupt_cause_;
 
+      private:
+        virtual ActionGroup* preExecute_(AtlasState*) { return nullptr; }
+
+        virtual ActionGroup* postExecute_(AtlasState*) { return nullptr; }
+
+        virtual ActionGroup* preException_(AtlasState*) { return nullptr; }
+
         void reset_()
         {
             pc_ = 0;
@@ -113,7 +120,6 @@ namespace atlas
             mem_writes_.clear();
         }
 
-      private:
         void postWrite_(const sparta::memory::BlockingMemoryIFNode::PostWriteAccess & data)
         {
             uint64_t prior_val = 0;

--- a/core/observers/Observer.hpp
+++ b/core/observers/Observer.hpp
@@ -55,15 +55,9 @@ namespace atlas
             return preExecute_(state);
         }
 
-        ActionGroup* postExecute(AtlasState* state)
-        {
-            return postExecute_(state);
-        }
+        ActionGroup* postExecute(AtlasState* state) { return postExecute_(state); }
 
-        ActionGroup* preException(AtlasState* state)
-        {
-            return preException_(state);
-        }
+        ActionGroup* preException(AtlasState* state) { return preException_(state); }
 
         virtual void stopSim() {}
 

--- a/core/observers/SimController.cpp
+++ b/core/observers/SimController.cpp
@@ -295,6 +295,9 @@ namespace atlas
                                const std::vector<std::string> & args,
                                ActionGroup*& fail_action_group)
         {
+            // TODO cnyce: Consider replacing all use of stringstream here to
+            // only send hex values as uint64_t and format in Python.
+
             switch (sim_cmd)
             {
                 case SimCommand::XLEN:

--- a/core/observers/SimController.cpp
+++ b/core/observers/SimController.cpp
@@ -686,7 +686,8 @@ namespace atlas
                         {
                             const auto & mem_write = mem_writes_[idx];
                             std::stringstream ss;
-                            ss << "0x" << std::hex << mem_write.addr << " 0x" << mem_write.prior_value << " 0x" << mem_write.value;
+                            ss << "0x" << std::hex << mem_write.addr << " 0x"
+                               << mem_write.prior_value << " 0x" << mem_write.value;
                             json += ss.str();
                             if (idx < mem_writes_.size() - 1)
                             {

--- a/core/observers/SimController.cpp
+++ b/core/observers/SimController.cpp
@@ -64,10 +64,14 @@ namespace atlas
             return nullptr;
         }
 
-        ActionGroup* postExecute(AtlasState* state)
+        ActionGroup* postExecute(AtlasState* state,
+                                 const std::vector<Observer::MemRead> & mem_reads,
+                                 const std::vector<Observer::MemWrite> & mem_writes)
         {
             if (break_on_post_execute_)
             {
+                mem_reads_ = mem_reads;
+                mem_writes_ = mem_writes;
                 sendString_("post_execute");
                 return enterLoop_(state);
             }
@@ -111,6 +115,8 @@ namespace atlas
             REG_VALUE,
             REG_WRITE,
             REG_DMI_WRITE,
+            MEM_READS,
+            MEM_WRITES,
             BREAKPOINT,
             FINISH_EXECUTE,
             CONTINUE_SIM,
@@ -170,6 +176,8 @@ namespace atlas
                 {"reg.value", SimCommand::REG_VALUE},
                 {"reg.write", SimCommand::REG_WRITE},
                 {"reg.dmiwrite", SimCommand::REG_DMI_WRITE},
+                {"mem.reads", SimCommand::MEM_READS},
+                {"mem.writes", SimCommand::MEM_WRITES},
                 {"sim.break", SimCommand::BREAKPOINT},
                 {"sim.finish_execute", SimCommand::FINISH_EXECUTE},
                 {"sim.continue", SimCommand::CONTINUE_SIM},
@@ -646,6 +654,56 @@ namespace atlas
                         return true;
                     }
 
+                case SimCommand::MEM_READS:
+                    {
+                        std::string json;
+                        for (size_t idx = 0; idx < mem_reads_.size(); ++idx)
+                        {
+                            const auto & mem_read = mem_reads_[idx];
+                            std::stringstream ss;
+                            ss << "0x" << std::hex << mem_read.addr << " 0x" << mem_read.value;
+                            json += ss.str();
+                            if (idx < mem_reads_.size() - 1)
+                            {
+                                json += ", ";
+                            }
+                        }
+
+                        if (json.empty())
+                        {
+                            sendError_("No memory reads");
+                            break;
+                        }
+
+                        sendString_(json);
+                        return true;
+                    }
+
+                case SimCommand::MEM_WRITES:
+                    {
+                        std::string json;
+                        for (size_t idx = 0; idx < mem_writes_.size(); ++idx)
+                        {
+                            const auto & mem_write = mem_writes_[idx];
+                            std::stringstream ss;
+                            ss << "0x" << std::hex << mem_write.addr << " 0x" << mem_write.prior_value << " 0x" << mem_write.value;
+                            json += ss.str();
+                            if (idx < mem_writes_.size() - 1)
+                            {
+                                json += ", ";
+                            }
+                        }
+
+                        if (json.empty())
+                        {
+                            sendError_("No memory writes");
+                            break;
+                        }
+
+                        sendString_(json);
+                        return true;
+                    }
+
                 case SimCommand::BREAKPOINT:
                     if (args.size() != 1)
                     {
@@ -716,6 +774,9 @@ namespace atlas
         bool break_on_pre_execute_ = false;
         bool break_on_post_execute_ = false;
         bool break_on_pre_exception_ = false;
+
+        std::vector<Observer::MemRead> mem_reads_;
+        std::vector<Observer::MemWrite> mem_writes_;
     };
 
     SimController::SimController() : endpoint_(std::make_shared<SimEndpoint>()) {}
@@ -729,7 +790,7 @@ namespace atlas
 
     ActionGroup* SimController::postExecute_(AtlasState* state)
     {
-        return endpoint_->postExecute(state);
+        return endpoint_->postExecute(state, mem_reads_, mem_writes_);
     }
 
     ActionGroup* SimController::preException_(AtlasState* state)


### PR DESCRIPTION
There is room for improvement here on how we show the memory reads/writes that occur during an instruction handler, but this first submission will help close out the remaining ISA tests. The reads and writes are just listed along the top "banner" with the RD/CSR changes for now. They are not given their own grid/table like the others since we haven't really discussed if that's appropriate or just clutter.