### PR TITLE
Fix bug in InstructionLogger

### DIFF
--- a/core/observers/InstructionLogger.cpp
+++ b/core/observers/InstructionLogger.cpp
@@ -209,7 +209,7 @@ namespace atlas
         {
             reset_();
             inst_oss_ << "core   " << state->getHartId() << ": " << (int)state->getPrivMode() << " "
-                      << HEX(state->getPc(), WIDTH) << " (" << HEX8(opcode) << ")";
+                      << HEX(state->getPrevPc(), WIDTH) << " (" << HEX8(opcode) << ")";
         }
 
         void writeDstRegister(const std::string & reg_name, const uint64_t reg_value,

--- a/core/observers/InstructionLogger.cpp
+++ b/core/observers/InstructionLogger.cpp
@@ -265,7 +265,6 @@ namespace atlas
             // that is the InstructionLogger's calling function name.
 
             // clang-format on
-
             INSTLOG(msg);
         }
 

--- a/core/observers/InstructionLogger.cpp
+++ b/core/observers/InstructionLogger.cpp
@@ -265,6 +265,7 @@ namespace atlas
             // that is the InstructionLogger's calling function name.
 
             // clang-format on
+
             INSTLOG(msg);
         }
 


### PR DESCRIPTION
`getPc()` at this call site is after `incrementPc_()` so we have to call `getPrevPc()` instead.