### PR TITLE
Miscellaneous Fixes for Instruction Decoding Support

### DIFF
--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -77,13 +77,13 @@ set(DEPENDS_INST_JSON_FILES
 
 add_custom_command(
   OUTPUT ${AUTOGEN_RV32_INST_JSON_FILES}
-  COMMAND python3 ${SIM_BASE}/scripts/GenInstructionJSON.py rv32imafdv_zicsr_zifencei
+  COMMAND python3 ${SIM_BASE}/scripts/GenInstructionJSON.py rv32imafdbv_zicsr_zifencei
   DEPENDS ${DEPENDS_INST_JSON_FILES}
 )
 
 add_custom_command(
   OUTPUT ${AUTOGEN_RV64_INST_JSON_FILES}
-  COMMAND python3 ${SIM_BASE}/scripts/GenInstructionJSON.py rv64imafdv_zicsr_zifencei
+  COMMAND python3 ${SIM_BASE}/scripts/GenInstructionJSON.py rv64imafdbv_zicsr_zifencei
   DEPENDS ${DEPENDS_INST_JSON_FILES}
 )
 

--- a/core/AtlasExtractor.cpp
+++ b/core/AtlasExtractor.cpp
@@ -37,9 +37,10 @@ namespace atlas
             }
             catch (const std::out_of_range & excp)
             {
-                sparta_assert(inst_handler_name_ == "nop", "Missing key in rv" << std::to_string(xlen)
-                                                         << " inst compute address handler map: "
-                                                         << inst_handler_name_);
+                sparta_assert(inst_handler_name_ == "nop",
+                              "Missing key in rv"
+                                  << std::to_string(xlen)
+                                  << " inst compute address handler map: " << inst_handler_name_);
             }
         }
 

--- a/core/AtlasExtractor.cpp
+++ b/core/AtlasExtractor.cpp
@@ -37,7 +37,7 @@ namespace atlas
             }
             catch (const std::out_of_range & excp)
             {
-                sparta_assert(false, "Missing key in rv" << std::to_string(xlen)
+                sparta_assert(inst_handler_name_ == "nop", "Missing key in rv" << std::to_string(xlen)
                                                          << " inst compute address handler map: "
                                                          << inst_handler_name_);
             }

--- a/core/AtlasState.cpp
+++ b/core/AtlasState.cpp
@@ -225,6 +225,14 @@ namespace atlas
             xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "a.json",
             xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "f.json",
             xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "d.json",
+            xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "zba.json",
+            xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "zbb.json",
+            xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "zbc.json",
+            xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "zbs.json",
+            xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "zve64x.json",
+            xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "zve64d.json",
+            xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "zve32x.json",
+            xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "zve32f.json",
             xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "zicsr.json",
             xlen_uarch_file_path + "/atlas_uarch_rv" + xlen_str + "zifencei.json"};
         return uarch_files;

--- a/core/AtlasState.hpp
+++ b/core/AtlasState.hpp
@@ -101,10 +101,13 @@ namespace atlas
         void updateMavisContext()
         {
             const mavis::MatchSet<mavis::Pattern> inclusions{inclusions_};
-            // FIXME: Use ISA string for context name and check if it already exists
-            mavis_->makeContext(std::to_string(pc_), extension_manager_.getJSONs(),
-                                getUArchFiles_(), mavis_uid_list_, {}, inclusions, {});
-            mavis_->switchContext(std::to_string(pc_));
+            const std::string context_name = std::accumulate(inclusions_.begin(), inclusions_.end(), std::string(""));
+            if (mavis_->hasContext(context_name) == false)
+            {
+                mavis_->makeContext(context_name, extension_manager_.getJSONs(),
+                                    getUArchFiles_(), mavis_uid_list_, {}, inclusions, {});
+            }
+            mavis_->switchContext(context_name);
         }
 
         bool getStopSimOnWfi() const { return stop_sim_on_wfi_; }

--- a/core/AtlasState.hpp
+++ b/core/AtlasState.hpp
@@ -101,11 +101,12 @@ namespace atlas
         void updateMavisContext()
         {
             const mavis::MatchSet<mavis::Pattern> inclusions{inclusions_};
-            const std::string context_name = std::accumulate(inclusions_.begin(), inclusions_.end(), std::string(""));
+            const std::string context_name =
+                std::accumulate(inclusions_.begin(), inclusions_.end(), std::string(""));
             if (mavis_->hasContext(context_name) == false)
             {
-                mavis_->makeContext(context_name, extension_manager_.getJSONs(),
-                                    getUArchFiles_(), mavis_uid_list_, {}, inclusions, {});
+                mavis_->makeContext(context_name, extension_manager_.getJSONs(), getUArchFiles_(),
+                                    mavis_uid_list_, {}, inclusions, {});
             }
             mavis_->switchContext(context_name);
         }

--- a/scripts/GenInstructionJSON.py
+++ b/scripts/GenInstructionJSON.py
@@ -68,6 +68,8 @@ class InstJSONGenerator():
                 for x in ext:
                     if "g" == x:
                         self.extensions.extend(['i', 'm', 'a', 'f', 'd'])
+                    elif "b" == x:
+                        self.extensions.extend(['zba', 'zbb', 'zbc', 'zbs'])
                     elif "v" == x:
                         self.extensions.extend(['zve64x', 'zve64d', 'zve32x', 'zve32f'])
                     else:

--- a/sim/AtlasAllocators.hpp
+++ b/sim/AtlasAllocators.hpp
@@ -47,7 +47,7 @@ namespace atlas
             return allocators;
         }
 
-        AtlasInstAllocator inst_allocator{3000, 2500};
-        AtlasExtractorAllocator extractor_allocator{3000, 2500};
+        AtlasInstAllocator inst_allocator{1000, 500};
+        AtlasExtractorAllocator extractor_allocator{5000, 4500};
     };
 } // namespace atlas


### PR DESCRIPTION
I have an ELF with a vsetvl instruction in it (currently unsupported) and found some issues related to how I hooked up the Bitmanip and Vector instructions to the nop handler.