### PR TITLE
Disable STF tests (clashes with sparta regress target)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ add_subdirectory(softfloat)
 
 # STF Library
 set(DISABLE_STF_DOXYGEN 1)
+set(DISABLE_STF_TESTS 1)
 include_directories(SYSTEM stf_lib)
 include(stf_lib/cmake/stf_linker_setup.cmake)
 setup_stf_linker(false)


### PR DESCRIPTION
The issue occurs when you try to build Atlas with SPARTA_SEARCH_DIR. Sparta already has a target named "regress" which clashes with the stf_lib/tests/CMakeLists.txt target also named "regress".