### PR TITLE
Added VLEN Parameter and Refactored Observers to Support Vector Registers

### DIFF
--- a/core/AtlasState.cpp
+++ b/core/AtlasState.cpp
@@ -41,6 +41,7 @@ namespace atlas
         sparta::Unit(core_tn),
         hart_id_(p->hart_id),
         isa_string_(p->isa_string),
+        vlen_(p->vlen),
         xlen_(getXlenFromIsaString_(isa_string_)),
         supported_isa_string_(std::string("rv" + std::to_string(xlen_) + "gcbv_zicsr_zifencei")),
         isa_file_path_(p->isa_file_path),
@@ -64,8 +65,9 @@ namespace atlas
         int_rset_ =
             RegisterSet::create(core_tn, json_dir + std::string("/reg_int.json"), "int_regs");
         fp_rset_ = RegisterSet::create(core_tn, json_dir + std::string("/reg_fp.json"), "fp_regs");
+        const std::string vec_reg_json = "/reg_vec" + std::to_string(vlen_) + ".json";
         vec_rset_ =
-            RegisterSet::create(core_tn, json_dir + std::string("/reg_vec.json"), "vec_regs");
+            RegisterSet::create(core_tn, json_dir + vec_reg_json, "vec_regs");
         csr_rset_ =
             RegisterSet::create(core_tn, json_dir + std::string("/reg_csr.json"), "csr_regs");
 

--- a/core/AtlasState.cpp
+++ b/core/AtlasState.cpp
@@ -66,8 +66,7 @@ namespace atlas
             RegisterSet::create(core_tn, json_dir + std::string("/reg_int.json"), "int_regs");
         fp_rset_ = RegisterSet::create(core_tn, json_dir + std::string("/reg_fp.json"), "fp_regs");
         const std::string vec_reg_json = "/reg_vec" + std::to_string(vlen_) + ".json";
-        vec_rset_ =
-            RegisterSet::create(core_tn, json_dir + vec_reg_json, "vec_regs");
+        vec_rset_ = RegisterSet::create(core_tn, json_dir + vec_reg_json, "vec_regs");
         csr_rset_ =
             RegisterSet::create(core_tn, json_dir + std::string("/reg_csr.json"), "csr_regs");
 

--- a/core/AtlasState.hpp
+++ b/core/AtlasState.hpp
@@ -56,15 +56,27 @@ namespace atlas
         class AtlasStateParameters : public sparta::ParameterSet
         {
           public:
-            AtlasStateParameters(sparta::TreeNode* node) : sparta::ParameterSet(node) {}
+            AtlasStateParameters(sparta::TreeNode* node) : sparta::ParameterSet(node)
+            {
+                vlen.addDependentValidationCallback(&AtlasStateParameters::validateVlen_, "VLEN constraint");
+            }
 
             PARAMETER(uint32_t, hart_id, 0, "Hart ID")
             PARAMETER(std::string, isa_string, "rv64gcbv_zicsr_zifencei", "ISA string")
+            PARAMETER(uint32_t, vlen, 128, "Vector register size in bits")
             PARAMETER(std::string, isa_file_path, "mavis_json", "Where are the Mavis isa files?")
             PARAMETER(std::string, uarch_file_path, "arch", "Where are the Atlas uarch files?")
             PARAMETER(std::string, csr_values, "arch/default_csr_values.json",
                       "Provides initial values of CSRs")
             PARAMETER(bool, stop_sim_on_wfi, false, "Executing a WFI instruction stops simulation")
+
+          private:
+            static bool validateVlen_(uint32_t & vlen_val, const sparta::TreeNode*)
+            {
+                const std::vector<uint32_t> valid_vlen_values{128, 256, 512, 1024, 2048};
+                return std::find(valid_vlen_values.begin(), valid_vlen_values.end(), vlen_val)
+                    != valid_vlen_values.end();
+            }
         };
 
         AtlasState(sparta::TreeNode* core_node, const AtlasStateParameters* p);
@@ -282,6 +294,9 @@ namespace atlas
 
         // ISA string
         const std::string isa_string_;
+
+        // VLEN (128, 256, 512, 1024 or 2048 bits)
+        const uint32_t vlen_;
 
         // XLEN (either 32 or 64 bit)
         uint64_t xlen_ = 64;

--- a/core/AtlasState.hpp
+++ b/core/AtlasState.hpp
@@ -58,7 +58,8 @@ namespace atlas
           public:
             AtlasStateParameters(sparta::TreeNode* node) : sparta::ParameterSet(node)
             {
-                vlen.addDependentValidationCallback(&AtlasStateParameters::validateVlen_, "VLEN constraint");
+                vlen.addDependentValidationCallback(&AtlasStateParameters::validateVlen_,
+                                                    "VLEN constraint");
             }
 
             PARAMETER(uint32_t, hart_id, 0, "Hart ID")
@@ -75,7 +76,7 @@ namespace atlas
             {
                 const std::vector<uint32_t> valid_vlen_values{128, 256, 512, 1024, 2048};
                 return std::find(valid_vlen_values.begin(), valid_vlen_values.end(), vlen_val)
-                    != valid_vlen_values.end();
+                       != valid_vlen_values.end();
             }
         };
 

--- a/core/observers/CoSimObserver.cpp
+++ b/core/observers/CoSimObserver.cpp
@@ -36,13 +36,15 @@ namespace atlas
     {
         for (auto & src_reg : src_regs_)
         {
-            last_event_.register_reads_.emplace_back(src_reg.reg_id, src_reg.reg_value);
+            last_event_.register_reads_.emplace_back(src_reg.reg_id,
+                                                     src_reg.reg_value.getByteVector());
         }
 
         for (auto & dst_reg : dst_regs_)
         {
-            last_event_.register_writes_.emplace_back(dst_reg.reg_id, dst_reg.reg_value,
-                                                      dst_reg.reg_prev_value);
+            last_event_.register_writes_.emplace_back(dst_reg.reg_id,
+                                                      dst_reg.reg_value.getByteVector(),
+                                                      dst_reg.reg_prev_value.getByteVector());
         }
 
         last_event_.done_ = true;

--- a/core/observers/InstructionLogger.cpp
+++ b/core/observers/InstructionLogger.cpp
@@ -45,16 +45,23 @@ namespace atlas
 
         virtual void writeImmediate(const uint64_t imm) { (void)imm; }
 
-        virtual void writeSrcRegister(const std::string &, const uint64_t) {}
+        virtual void writeSrcRegister(const std::string &, const Observer::RegValue &) {}
 
-        virtual void writeDstRegister(const std::string &, const uint64_t, const uint64_t) {}
+        virtual void writeDstRegister(const std::string &, const Observer::RegValue &,
+                                      const Observer::RegValue &)
+        {
+        }
 
-        virtual void writeCsrRead(const std::string &, const uint64_t) {}
+        virtual void writeCsrRead(const std::string &, const Observer::RegValue &) {}
 
-        virtual void writeCsrWrite(const std::string &, const uint64_t, const uint64_t) {}
+        virtual void writeCsrWrite(const std::string &, const Observer::RegValue &,
+                                   const Observer::RegValue &)
+        {
+        }
 
         virtual void writeDstCSR(const std::string & reg_name, const uint32_t reg_num,
-                                 const uint64_t reg_value, const uint64_t reg_prev_value)
+                                 const Observer::RegValue & reg_value,
+                                 const Observer::RegValue & reg_prev_value)
         {
             (void)reg_num;
             writeDstRegister(reg_name, reg_value, reg_prev_value);
@@ -134,39 +141,39 @@ namespace atlas
             postExecute_(inst_oss_.str());
         }
 
-        void writeSrcRegister(const std::string & reg_name, const uint64_t reg_value) override
+        void writeSrcRegister(const std::string & reg_name,
+                              const Observer::RegValue & reg_value) override
         {
             reset_();
             inst_oss_ << "   src " << std::setfill(' ') << std::setw(3) << reg_name << ": "
-                      << HEX(reg_value, getRegWidth());
+                      << reg_value;
             postExecute_(inst_oss_.str());
         }
 
-        void writeDstRegister(const std::string & reg_name, const uint64_t reg_value,
-                              const uint64_t reg_prev_value) override
+        void writeDstRegister(const std::string & reg_name, const Observer::RegValue & reg_value,
+                              const Observer::RegValue & reg_prev_value) override
         {
             reset_();
             inst_oss_ << "   dst " << std::setfill(' ') << std::setw(3) << reg_name << ": "
-                      << HEX(reg_value, getRegWidth())
-                      << " (prev: " << HEX(reg_prev_value, getRegWidth()) << ")";
+                      << reg_value << " (prev: " << reg_prev_value << ")";
             postExecute_(inst_oss_.str());
         }
 
-        void writeCsrRead(const std::string & reg_name, const uint64_t reg_value) override
+        void writeCsrRead(const std::string & reg_name,
+                          const Observer::RegValue & reg_value) override
         {
             reset_();
             inst_oss_ << "   csr " << std::setfill(' ') << std::setw(3) << reg_name << ": "
-                      << HEX(reg_value, getRegWidth());
+                      << reg_value;
             postExecute_(inst_oss_.str());
         }
 
-        void writeCsrWrite(const std::string & reg_name, const uint64_t reg_value,
-                           const uint64_t reg_prev_value) override
+        void writeCsrWrite(const std::string & reg_name, const Observer::RegValue & reg_value,
+                           const Observer::RegValue & reg_prev_value) override
         {
             reset_();
             inst_oss_ << "   csr " << std::setfill(' ') << std::setw(3) << reg_name << ": "
-                      << HEX(reg_value, getRegWidth())
-                      << " (prev: " << HEX(reg_prev_value, getRegWidth()) << ")";
+                      << reg_value << " (prev: " << reg_prev_value << ")";
             postExecute_(inst_oss_.str());
         }
 
@@ -237,19 +244,19 @@ namespace atlas
                       << HEX(state->getPrevPc(), getRegWidth()) << " (" << HEX8(opcode) << ")";
         }
 
-        void writeDstRegister(const std::string & reg_name, const uint64_t reg_value,
-                              const uint64_t reg_prev_value) override
+        void writeDstRegister(const std::string & reg_name, const Observer::RegValue & reg_value,
+                              const Observer::RegValue & reg_prev_value) override
         {
             (void)reg_prev_value;
-            inst_oss_ << " " << std::setw(4) << std::left << reg_name
-                      << HEX(reg_value, getRegWidth());
+            inst_oss_ << " " << std::setw(4) << std::left << reg_name << reg_value;
         }
 
         void writeDstCSR(const std::string & reg_name, const uint32_t reg_num,
-                         const uint64_t reg_value, const uint64_t reg_prev_value) override
+                         const Observer::RegValue & reg_value,
+                         const Observer::RegValue & reg_prev_value) override
         {
             (void)reg_prev_value;
-            inst_oss_ << " c" << reg_num << "_" << reg_name << " " << HEX(reg_value, getRegWidth());
+            inst_oss_ << " c" << reg_num << "_" << reg_name << " " << reg_value;
         }
 
         void writeMemRead(const Observer::MemRead & mem_read) override

--- a/core/observers/Observer.cpp
+++ b/core/observers/Observer.cpp
@@ -68,8 +68,7 @@ namespace atlas
                         sparta_assert(false, "Invalid register type!");
                 }
                 sparta_assert(reg != nullptr);
-                const uint64_t value = readRegister_(reg);
-                dst_reg.reg_value.setValue(value);
+                dst_reg.reg_value.setValue(readRegister_(reg));
             }
         }
 
@@ -92,39 +91,35 @@ namespace atlas
                 if (inst->hasRs1())
                 {
                     const auto rs1_reg = inst->getRs1Reg();
-                    const uint64_t value = readRegister_(rs1_reg);
-                    src_regs_.emplace_back(getRegId(rs1_reg), value);
+                    src_regs_.emplace_back(getRegId(rs1_reg), readRegister_(rs1_reg));
                 }
 
                 if (inst->hasRs2())
                 {
                     const auto rs2_reg = inst->getRs2Reg();
-                    const uint64_t value = readRegister_(rs2_reg);
-                    src_regs_.emplace_back(getRegId(rs2_reg), value);
+                    src_regs_.emplace_back(getRegId(rs2_reg), readRegister_(rs2_reg));
+                }
+
+                if (inst->hasRs3())
+                {
+                    const auto rs3_reg = inst->getRs3Reg();
+                    src_regs_.emplace_back(getRegId(rs3_reg), readRegister_(rs3_reg));
                 }
 
                 // Get initial value of destination registers
                 if (inst->hasRd())
                 {
                     const auto rd_reg = inst->getRdReg();
-                    const uint64_t value = readRegister_(rd_reg);
-                    dst_regs_.emplace_back(getRegId(rd_reg), value);
+                    dst_regs_.emplace_back(getRegId(rd_reg), readRegister_(rd_reg));
+                }
+
+                if (inst->hasRd2())
+                {
+                    const auto rd2_reg = inst->getRd2Reg();
+                    dst_regs_.emplace_back(getRegId(rd2_reg), readRegister_(rd2_reg));
                 }
             }
         }
-    }
-
-    uint64_t Observer::readRegister_(const sparta::Register* reg)
-    {
-        const uint32_t reg_width = reg->getNumBytes();
-
-        if (reg_width == 8)
-            return reg->dmiRead<RV32>();
-        if (reg_width == 16)
-            return reg->dmiRead<RV64>();
-
-        sparta_assert(false, "Invalid register width");
-        return 0;
     }
 
     void Observer::postCsrWrite_(const sparta::TreeNode &, const sparta::TreeNode &,
@@ -214,19 +209,7 @@ namespace atlas
 
     std::ostream & operator<<(std::ostream & os, const Observer::RegValue & reg_value)
     {
-        const auto num_bytes = reg_value.getNumBytes();
-        if (num_bytes == 8)
-        {
-            os << HEX16(reg_value.getValue<uint64_t>());
-        }
-        else if (num_bytes == 4)
-        {
-            os << HEX8(reg_value.getValue<uint32_t>());
-        }
-        else
-        {
-            os << "???";
-        }
+        os << "0x" << sparta::utils::bin_to_hexstr(reg_value.getByteVector().data(), reg_value.size(), "");
         return os;
     }
 } // namespace atlas

--- a/core/observers/Observer.cpp
+++ b/core/observers/Observer.cpp
@@ -3,6 +3,8 @@
 #include "core/AtlasState.hpp"
 #include "core/AtlasInst.hpp"
 
+#include "sparta/utils/LogUtils.hpp"
+
 namespace atlas
 {
     void Observer::preExecute(AtlasState* state)
@@ -67,7 +69,7 @@ namespace atlas
                 }
                 sparta_assert(reg != nullptr);
                 const uint64_t value = readRegister_(reg);
-                dst_reg.setValue(value);
+                dst_reg.reg_value.setValue(value);
             }
         }
 
@@ -114,7 +116,7 @@ namespace atlas
 
     uint64_t Observer::readRegister_(const sparta::Register* reg)
     {
-        const uint32_t reg_width = getRegWidth();
+        const uint32_t reg_width = reg->getNumBytes();
 
         if (reg_width == 8)
             return reg->dmiRead<RV32>();
@@ -137,7 +139,7 @@ namespace atlas
         // If this CSR has already been written to, just update the final value
         if (csr_writes_.find(csr_num) != csr_writes_.end())
         {
-            csr_writes_.at(csr_num).setValue(final_value);
+            csr_writes_.at(csr_num).reg_value.setValue(final_value);
         }
         else
         {
@@ -208,5 +210,23 @@ namespace atlas
         mem_read.size = data.size;
         mem_read.value = val;
         mem_reads_.push_back(mem_read);
+    }
+
+    std::ostream & operator<<(std::ostream & os, const Observer::RegValue & reg_value)
+    {
+        const auto num_bytes = reg_value.getNumBytes();
+        if (num_bytes == 8)
+        {
+            os << HEX16(reg_value.getValue<uint64_t>());
+        }
+        else if (num_bytes == 4)
+        {
+            os << HEX8(reg_value.getValue<uint32_t>());
+        }
+        else
+        {
+            os << "???";
+        }
+        return os;
     }
 } // namespace atlas

--- a/scripts/GenCSRHeaders.py
+++ b/scripts/GenCSRHeaders.py
@@ -262,7 +262,7 @@ def gen_csr_field_idxs_header(reg_size):
     reg_csr_json_filename = os.path.join(json_dir, "reg_csr.json")
     reg_fp_json_filename  = os.path.join(json_dir, "reg_fp.json")
     reg_int_json_filename = os.path.join(json_dir, "reg_int.json")
-    reg_vec_json_filename = os.path.join(json_dir, "reg_vec.json")
+    reg_vec_json_filename = os.path.join(json_dir, "reg_vec128.json")
 
     def WriteRegisterFieldIdxs(reg_type, reg_json_filename, fout):
         with open(reg_json_filename) as reg_json_file:

--- a/scripts/GenRISCVRegisterDefinitions.py
+++ b/scripts/GenRISCVRegisterDefinitions.py
@@ -34,7 +34,7 @@ def main():
     registers["fp"]  = GenRegisterJSON(RegisterGroup.FP,  32, RV64_XLEN)
     for vlen in SUPPORTED_VLENS:
         name = "vec" + str(vlen)
-        registers[name] = GenRegisterJSON(RegisterGroup.VEC, 32, vlen)
+        registers[name] = GenRegisterJSON(RegisterGroup.VEC, 32, int(vlen/8))
     registers["csr"] = GenRegisterJSON(RegisterGroup.CSR, 0,  RV64_XLEN)
 
     # Add register for the PC

--- a/scripts/GenRISCVRegisterDefinitions.py
+++ b/scripts/GenRISCVRegisterDefinitions.py
@@ -27,27 +27,29 @@ def main():
     os.chdir("rv64")
 
     # Generate rv64g int, fp and CSR registers
+    registers = {}
     RV64_XLEN = 8
-    VLEN = 32
-    reg_int = GenRegisterJSON(RegisterGroup.INT, 32, RV64_XLEN)
-    reg_fp  = GenRegisterJSON(RegisterGroup.FP,  32, RV64_XLEN)
-    reg_vec = GenRegisterJSON(RegisterGroup.VEC, 32, VLEN)
-    reg_csr = GenRegisterJSON(RegisterGroup.CSR, 0,  RV64_XLEN)
+    SUPPORTED_VLENS = [128, 256, 512, 1024, 2048]
+    registers["int"] = GenRegisterJSON(RegisterGroup.INT, 32, RV64_XLEN)
+    registers["fp"]  = GenRegisterJSON(RegisterGroup.FP,  32, RV64_XLEN)
+    for vlen in SUPPORTED_VLENS:
+        name = "vec" + str(vlen)
+        registers[name] = GenRegisterJSON(RegisterGroup.VEC, 32, vlen)
+    registers["csr"] = GenRegisterJSON(RegisterGroup.CSR, 0,  RV64_XLEN)
 
     # Add register for the PC
     num = 32
-    reg_int.add_custom_register("pc", num, "Program counter", 8, [], {}, True)
+    registers["int"].add_custom_register("pc", num, "Program counter", 8, [], {}, True)
 
     # Add registers for atomic load-reservation and store-conditional instructions
     num += 1
-    reg_int.add_custom_register("resv_addr", num, "Load reservation address", 8, [], {}, True)
+    registers["int"].add_custom_register("resv_addr", num, "Load reservation address", 8, [], {}, True)
     num += 1
-    reg_int.add_custom_register("resv_valid", num, "Load reservation valid", 8, [], {}, True)
+    registers["int"].add_custom_register("resv_valid", num, "Load reservation valid", 8, [], {}, True)
 
-    reg_int.write_json("reg_int.json")
-    reg_fp.write_json("reg_fp.json")
-    reg_vec.write_json("reg_vec.json")
-    reg_csr.write_json("reg_csr.json")
+    for name, regs in registers.items():
+        filename = "reg_" + name + ".json"
+        regs.write_json(filename)
 
     # Make rv32 directory if it doesn't exist
     os.chdir("..")
@@ -57,25 +59,24 @@ def main():
 
     # Generate rv32g int, fp and CSR registers
     RV32_XLEN = 4
-    reg_int = GenRegisterJSON(RegisterGroup.INT, 32, RV32_XLEN)
-    reg_fp  = GenRegisterJSON(RegisterGroup.FP,  32, RV32_XLEN)
-    reg_vec = GenRegisterJSON(RegisterGroup.VEC, 32, VLEN)
-    reg_csr = GenRegisterJSON(RegisterGroup.CSR, 0,  RV32_XLEN)
+    registers["int"] = GenRegisterJSON(RegisterGroup.INT, 32, RV32_XLEN)
+    registers["fp"] = GenRegisterJSON(RegisterGroup.FP,  32, RV32_XLEN)
+    # Vector registers are the same for RV32
+    registers["csr"] = GenRegisterJSON(RegisterGroup.CSR, 0,  RV32_XLEN)
 
     # Add register for the PC
     num = 32
-    reg_int.add_custom_register("pc", num, "Program counter", 4, [], {}, True)
+    registers["int"].add_custom_register("pc", num, "Program counter", 4, [], {}, True)
 
     # Add registers for atomic load-reservation and store-conditional instructions
     num += 1
-    reg_int.add_custom_register("resv_addr", num, "Load reservation address", 4, [], {}, True)
+    registers["int"].add_custom_register("resv_addr", num, "Load reservation address", 4, [], {}, True)
     num += 1
-    reg_int.add_custom_register("resv_valid", num, "Load reservation valid", 4, [], {}, True)
+    registers["int"].add_custom_register("resv_valid", num, "Load reservation valid", 4, [], {}, True)
 
-    reg_int.write_json("reg_int.json");
-    reg_fp.write_json("reg_fp.json");
-    reg_vec.write_json("reg_vec.json")
-    reg_csr.write_json("reg_csr.json");
+    for name, regs in registers.items():
+        filename = "reg_" + name + ".json"
+        regs.write_json(filename)
 
     # Generate Atlas header files
     os.chdir("..")

--- a/test/register/Register_test.cpp
+++ b/test/register/Register_test.cpp
@@ -891,7 +891,7 @@ int main()
     testRegFileNoThrow("reg_csr.json");
     testRegFileNoThrow("reg_int.json");
     testRegFileNoThrow("reg_fp.json");
-    testRegFileNoThrow("reg_vec.json");
+    testRegFileNoThrow("reg_vec128.json");
 
     // Register I/O
 


### PR DESCRIPTION
Added support for VLENs of 128, 256, 512, 1024 and 2048. Each VLEN requires a separate vector register JSON. Also refactored the Observer classes to store register values as byte vectors. This is required since vector registers are larger than 64-bits and cannot be stored in a standard type.