### PR TITLE
fixed bugs in vector extension where mask register is the dest (#31)

### DIFF
--- a/core/inst_handlers/v/RvvFloatInsts.cpp
+++ b/core/inst_handlers/v/RvvFloatInsts.cpp
@@ -1245,15 +1245,28 @@ namespace pegasus
                 auto index = iter.getIndex();
                 if constexpr (opMode.src1 == OperandMode::Mode::V)
                 {
-                    elems_vd.getElement(index).setBit(func(elems_vs2.getElement(index).getVal(),
-                                                           elems_vs1.getElement(index).getVal()));
+                    if (func(elems_vs2.getElement(index).getVal(),
+                             elems_vs1.getElement(index).getVal()))
+                    {
+                        elems_vd.setBit(index);
+                    }
+                    else
+                    {
+                        elems_vd.clearBit(index);
+                    }
                 }
                 else if constexpr (opMode.src1 == OperandMode::Mode::F)
                 {
-                    elems_vd.getElement(index).setBit(
-                        func(elems_vs2.getElement(index).getVal(),
+                    if (func(elems_vs2.getElement(index).getVal(),
                              static_cast<UintType<elemWidth>>(
-                                 READ_FP_REG<RV64>(state, inst->getRs1()))));
+                                 READ_FP_REG<RV64>(state, inst->getRs1()))))
+                    {
+                        elems_vd.setBit(index);
+                    }
+                    else
+                    {
+                        elems_vd.clearBit(index);
+                    }
                 }
             }
         };

--- a/core/inst_handlers/v/RvvIntegerInsts.cpp
+++ b/core/inst_handlers/v/RvvIntegerInsts.cpp
@@ -1776,7 +1776,14 @@ namespace pegasus
             {
                 c = static_cast<decltype(b)>(elems_v0.getBit(index));
             }
-            elems_vd.getElement(index).setVal(detectFunc(a, b, c));
+            if (detectFunc(a, b, c))
+            {
+                elems_vd.setBit(index);
+            }
+            else
+            {
+                elems_vd.clearBit(index);
+            }
         }
 
         return ++action_it;


### PR DESCRIPTION
Following benchmarks have exact same output:

- blackscholes_args
- jacobi_2d_args

Following benchmarks have different output due to random number generation, but output value seems making sense:

- streamcluster_args
- lavaMD_args