### PR TITLE
Svinval Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ See [Python IDE for Pegasus](IDE/README.md)
 | **Sstvala** stval must be written with the faulting virtual address for load, store, and instruction page-fault, access-fault, and misaligned exceptions, and for breakpoint exceptions other than those caused by execution of the EBREAK or C.EBREAK instructions. For virtual-instruction and illegal-instruction exceptions, stval must be written with the faulting instruction. | :white_check_mark: |
 | **Sscounterenw** For any hpmcounter that is not read-only zero, the corresponding bit in scounteren must be writable. | :x: |
 | **Svpbmt** Page-based memory types
-| **Svinval** Fine-grained address-translation cache invalidation. | :x: |
+| **Svinval** Fine-grained address-translation cache invalidation. | :white_check_mark: |
 | **Svnapot** NAPOT translation contiguity. | :x: |
 | **Sstc** supervisor-mode timer interrupts. | :x: |
 | **Sscofpmf** count overflow and mode-based filtering. | :x: |

--- a/scripts/GenInstructionJSON.py
+++ b/scripts/GenInstructionJSON.py
@@ -71,6 +71,10 @@ from insts.RVV_INST import RVZVE64X_INST
 from insts.RVH_INST import RV32H_INST
 from insts.RVH_INST import RV64H_INST
 
+
+from insts.RVSVINVAL_INST import RV32SVINVAL_INST
+from insts.RVSVINVAL_INST import RV64SVINVAL_INST
+
 # Mavis extensions
 from insts.RVI_INST import RVI_MAVIS_EXTS
 from insts.RVM_INST import RVM_MAVIS_EXTS
@@ -102,6 +106,8 @@ from insts.RVZFA_INST import RVZFA_MAVIS_EXTS
 from insts.RVV_INST import RVV_MAVIS_EXTS
 
 from insts.RVH_INST import RVH_MAVIS_EXTS
+
+from insts.RVSVINVAL_INST import RVSVINVAL_MAVIS_EXTS
 
 class InstJSONGenerator():
     """Generates instruction definition JSON files.
@@ -236,25 +242,9 @@ def main():
 
     # RVA23
     # FIXME: At some point, we will read in the Mavis profile JSONs to get the
-    # list of supported extensions. For now, I've hardcoded it here.
-    RVA23_RV64_SUPPORTED_EXTENSIONS = ['i', 'c', 'zca', 'zcb', 'm', 'zmmul',
-                                       'a', 'zalrsc', 'zaamo', 'f', 'zcf',
-                                       'd', 'zcd', 'zfh', 'zfhmin', 'zfhmind',
-                                       'b', 'zba', 'zbb', 'zbc', 'zbs', 'zbkb',
-                                       'zicsr', 'zifencei', 'zicbop', 'zicbom',
-                                       'zicboz', 'zihintntl', 'zihintpause',
-                                       'zicond', 'zcmp', 'zcmt', 'zabha', 'zfa',
-                                       'v', 'zve32x', 'zve32f', 'zve64f', 'zve64d',
-                                       'zve64x', 'h']
-    RVA23_RV32_SUPPORTED_EXTENSIONS = ['i', 'c', 'zca', 'zcb', 'm', 'zmmul',
-                                       'a', 'zalrsc', 'zaamo', 'f', 'zcf',
-                                       'd', 'zcd', 'zfh', 'zfhmin', 'zfhmind',
-                                       'b', 'zba', 'zbb', 'zbc', 'zbs', 'zbkb',
-                                       'zicsr', 'zifencei', 'zicbop', 'zicbom',
-                                       'zicboz', 'zihintntl', 'zihintpause',
-                                       'zicond', 'zcmp', 'zcmt', 'zabha', 'zilsd', 'zfa',
-                                       'v', 'zve32x', 'zve32f', 'zve64f', 'zve64d',
-                                       'zve64x', 'h']
+    # list of supported extensions. For now, just assume everything is included.
+    RVA23_RV64_SUPPORTED_EXTENSIONS = rv64_exts
+    RVA23_RV32_SUPPORTED_EXTENSIONS = rv32_exts
     rva23_r64_exts = [ext for ext in rv64_exts if ext in RVA23_RV64_SUPPORTED_EXTENSIONS]
     rva23_r32_exts = [ext for ext in rv32_exts if ext in RVA23_RV32_SUPPORTED_EXTENSIONS]
     rva23_pegasus_uarch_rv64_jsons = [ext for ext in pegasus_uarch_rv64_jsons if ext in RVA23_RV64_SUPPORTED_EXTENSIONS]

--- a/scripts/insts/RVSVINVAL_INST.py
+++ b/scripts/insts/RVSVINVAL_INST.py
@@ -1,0 +1,15 @@
+RVSVINVAL_MAVIS_EXTS = ["svinval"]
+
+RV32SVINVAL_INST = [
+    {'mnemonic': 'sinval.vma', 'handler': 'nop', 'cost': 1, 'tags': 'SVINVAL_EXT_32', 'memory': False, 'cof': False},
+    {'mnemonic': 'sfence.w.inval', 'handler': 'nop', 'cost': 1, 'tags': 'SVINVAL_EXT_32', 'memory': False, 'cof': False},
+    {'mnemonic': 'hinval.vvma', 'handler': 'nop', 'cost': 1, 'tags': 'SVINVAL_EXT_32', 'memory': False, 'cof': False},
+    {'mnemonic': 'hinval.gvma', 'handler': 'nop', 'cost': 1, 'tags': 'SVINVAL_EXT_32', 'memory': False, 'cof': False}
+]
+
+RV64SVINVAL_INST = [
+    {'mnemonic': 'sinval.vma', 'handler': 'nop', 'cost': 1, 'tags': 'SVINVAL_EXT_64', 'memory': False, 'cof': False},
+    {'mnemonic': 'sfence.w.inval', 'handler': 'nop', 'cost': 1, 'tags': 'SVINVAL_EXT_64', 'memory': False, 'cof': False},
+    {'mnemonic': 'hinval.vvma', 'handler': 'nop', 'cost': 1, 'tags': 'SVINVAL_EXT_64', 'memory': False, 'cof': False},
+    {'mnemonic': 'hinval.gvma', 'handler': 'nop', 'cost': 1, 'tags': 'SVINVAL_EXT_64', 'memory': False, 'cof': False}
+]


### PR DESCRIPTION
Hooked up the Svinval cache invalidation instructions to nops since Pegasus doesn't model caches or a TLB.