### PR TITLE
fix lr/sc and reservation

### DIFF
--- a/core/PegasusCore.cpp
+++ b/core/PegasusCore.cpp
@@ -453,7 +453,7 @@ namespace pegasus
     {
         pauseCounterExpires_(hart_id);
         PegasusState* state = threads_[hart_id];
-        state->unregisterWaitOnReservationSet();
+        state->unregisterWaitOnReservationSetCB();
     }
 
     template <bool IS_UNIT_TEST> bool PegasusCore::compare(const PegasusCore* core) const

--- a/core/PegasusCore.hpp
+++ b/core/PegasusCore.hpp
@@ -147,6 +147,9 @@ namespace pegasus
                 }
             }
             reservations_.at(hart_id) = paddr;
+            auto & state = threads_.at(hart_id);
+            state->storeOnReservationSet(false);
+            state->registerStoreOnReservationSetCB();
         }
 
         Reservation & getReservation(HartId hart_id) { return reservations_.at(hart_id); }
@@ -156,12 +159,16 @@ namespace pegasus
             return reservations_.at(hart_id);
         }
 
-        void clearReservations()
+        void clearReservation(HartId hart_id)
         {
-            for (auto & reservation : reservations_)
+            auto & reservation = reservations_.at(hart_id);
+            auto & state = threads_.at(hart_id);
+            reservation.clearValid();
+            if (!state->storeOnReservationSetOccurred()) // Callback has not been unregistered
             {
-                reservation.clearValid();
+                state->unregisterStoreOnReservationSetCB();
             }
+            state->storeOnReservationSet(false);
         }
 
         const InstHandlers* getInstHandlers() const { return &inst_handlers_; }

--- a/core/PegasusState.hpp
+++ b/core/PegasusState.hpp
@@ -308,9 +308,18 @@ namespace pegasus
         void cleanup();
 
         // Register a WaitOnReservationSet notification.
-        void registerWaitOnReservationSet();
+        void registerWaitOnReservationSetCB();
         // Unregister a WaitOnReservationSet notification.
-        void unregisterWaitOnReservationSet();
+        void unregisterWaitOnReservationSetCB();
+
+        // Register a StoreOnReservationSet notification.
+        void registerStoreOnReservationSetCB();
+        // Unregister a StoreOnReservationSet notification.
+        void unregisterStoreOnReservationSetCB();
+
+        bool storeOnReservationSetOccurred() { return storeOnReservationSet_; };
+
+        void storeOnReservationSet(bool v) { storeOnReservationSet_ = v; }
 
       private:
         void onBindTreeEarly_() override;
@@ -337,7 +346,12 @@ namespace pegasus
         Action::ItrType pauseSim_(PegasusState*, Action::ItrType action_it) { return ++action_it; }
 
         void
-        waitOnReservationSet_(const sparta::memory::BlockingMemoryIFNode::PostWriteAccess & data);
+        waitOnReservationSetCB_(const sparta::memory::BlockingMemoryIFNode::PostWriteAccess & data);
+
+        // This callback is only registered when Reservation is valid and storeOnReservation has not
+        // occurred.
+        void storeOnReservationSetCB_(
+            const sparta::memory::BlockingMemoryIFNode::PostWriteAccess & data);
 
         //! Hart ID
         const HartId hart_id_;
@@ -451,6 +465,9 @@ namespace pegasus
         // Co-simulation debug utils
         std::unordered_map<std::string, int> reg_ids_by_name_;
         SimController* sim_controller_ = nullptr;
+
+        // Whether a store has occured on reservation set.
+        bool storeOnReservationSet_ = false;
 
         // Event friend class for cosim. Allows direct state manipulation
         // during flush (rollback) operations.

--- a/core/inst_handlers/a/RvaInstsBase.hpp
+++ b/core/inst_handlers/a/RvaInstsBase.hpp
@@ -111,16 +111,20 @@ namespace pegasus
         auto xlation_state = inst->getTranslationState();
 
         XLEN fail_code = 1; // assume bad
+
+        // From RISC-V spec:
+        //
+        // An SC may succeed only if no store from another hart to the
+        // reservation set can be observed to have occurred between the LR and the SC,
+        // and if there is no other SC between the LR and itself in program order.
         if (const auto & resv = state->getCore()->getReservation(state->getHartId());
-            resv.isValid())
+            resv.isValid() && resv == xlation_state->getResult().getPAddr()
+            && !state->storeOnReservationSetOccurred())
         {
-            if (resv == xlation_state->getResult().getPAddr())
-            {
-                const uint64_t rs2_val = READ_INT_REG<XLEN>(state, inst->getRs2());
-                state->writeMemory<SIZE>(xlation_state->getResult(), rs2_val,
-                                         MemAccessSource::INSTRUCTION);
-                fail_code = 0;
-            }
+            const uint64_t rs2_val = READ_INT_REG<XLEN>(state, inst->getRs2());
+            state->writeMemory<SIZE>(xlation_state->getResult(), rs2_val,
+                                     MemAccessSource::INSTRUCTION);
+            fail_code = 0;
         }
         xlation_state->popResult();
 
@@ -128,14 +132,7 @@ namespace pegasus
         //
         // Regardless of success or failure, executing an SC instruction invalidates
         // any reservation held by this hart.
-        //
-        // An SC may succeed only if no store from another hart to the
-        // reservation set can be observed to have occurred between the LR and the SC,
-        // and if there is no other SC between the LR and itself in program order.
-        // FIXME: All store instructions can invalidate a reservation, not just a SC
-
-        // Always clear all reservations after a SC
-        state->getCore()->clearReservations();
+        state->getCore()->clearReservation(state->getHartId());
 
         WRITE_INT_REG<XLEN>(state, inst->getRd(), fail_code);
         return ++action_it;

--- a/core/inst_handlers/zawrs/RvzawrsInsts.cpp
+++ b/core/inst_handlers/zawrs/RvzawrsInsts.cpp
@@ -29,7 +29,7 @@ namespace pegasus
         static_assert(std::is_same_v<XLEN, RV64> || std::is_same_v<XLEN, RV32>);
 
         state->pauseHart(SimPauseReason::WRS_NTO);
-        state->registerWaitOnReservationSet();
+        state->registerWaitOnReservationSetCB();
 
         return ++action_it;
     }
@@ -40,7 +40,7 @@ namespace pegasus
         static_assert(std::is_same_v<XLEN, RV64> || std::is_same_v<XLEN, RV32>);
 
         state->pauseHart(SimPauseReason::WRS_STO);
-        state->registerWaitOnReservationSet();
+        state->registerWaitOnReservationSetCB();
 
         return ++action_it;
     }


### PR DESCRIPTION
Fixed "lr sc" instruction handling.
Now the code is doing exactly what the comment indicated.
Elf test needs to be gdb'd to ensure the correct sequence is executed. Passing the test itself cannot guarantee correctness.