### PR TITLE
Removed ExtensionManager from PegasusCore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ FetchContent_MakeAvailable(spike)
 ################################################################################
 
 if (PROJECT_IS_TOP_LEVEL)
-  find_program(CLANGFORMAT_EXECUTABLE NAMES clang-format-15 clang-format-16 clang-format)
+  find_program(CLANGFORMAT_EXECUTABLE NAMES clang-format)
 
   execute_process (
     COMMAND
@@ -167,7 +167,7 @@ if (PROJECT_IS_TOP_LEVEL)
        CLANGFORMAT_VERSION_OUTPUT
   )
 
-  set(REQUIRED_CLANGFORMAT_VERSION "15")
+  set(REQUIRED_CLANGFORMAT_VERSION "18")
 
   # Extract the version number from the output
   string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" CLANGFORMAT_VERSION ${CLANGFORMAT_VERSION_OUTPUT})
@@ -188,9 +188,6 @@ if (PROJECT_IS_TOP_LEVEL)
        ${SIM_BASE}
   )
 
-  # CPUTopology is pretty clean as it is.  There's an option to NOT
-  # collapse the array of structures in clang-format v16, but we're not
-  # there yet
   add_custom_target(clangformat
     COMMAND
        ${CLANGFORMAT_EXECUTABLE} -i --files=${CMAKE_CURRENT_BINARY_DIR}/clang-format-files.out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ FetchContent_MakeAvailable(spike)
 ################################################################################
 
 if (PROJECT_IS_TOP_LEVEL)
-  find_program(CLANGFORMAT_EXECUTABLE NAMES clang-format)
+  find_program(CLANGFORMAT_EXECUTABLE NAMES clang-format-15 clang-format-16 clang-format)
 
   execute_process (
     COMMAND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ FetchContent_MakeAvailable(spike)
 ################################################################################
 
 if (PROJECT_IS_TOP_LEVEL)
-  find_program(CLANGFORMAT_EXECUTABLE NAMES clang-format-15 clang-format-16 clang-format)
+  find_program(CLANGFORMAT_EXECUTABLE NAMES clang-format)
 
   execute_process (
     COMMAND

--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -2,6 +2,8 @@ set(DEPENDS_REGISTER_PYTHON_SCRIPTS
   ${SIM_BASE}/scripts/GenRISCVRegisterDefinitions.py
   ${SIM_BASE}/scripts/RV32_CSR.py
   ${SIM_BASE}/scripts/RV64_CSR.py
+  ${SIM_BASE}/scripts/RV32H_CSR.py
+  ${SIM_BASE}/scripts/RV64H_CSR.py
   ${SIM_BASE}/scripts/REG_CONSTS.py
 )
 

--- a/core/Exception.cpp
+++ b/core/Exception.cpp
@@ -169,7 +169,7 @@ namespace pegasus
             WRITE_CSR_FIELD<XLEN>(state, SSTATUS, "sie", sie_val);
 
             // Update HSTATUS
-            if (state->getCore()->hasHypervisor())
+            if (state->hasHypervisor())
             {
                 const uint64_t spv_val = prev_virt_mode;
                 WRITE_CSR_FIELD<XLEN>(state, HSTATUS, "spv", spv_val);
@@ -217,7 +217,7 @@ namespace pegasus
             const uint64_t mie_val = 0;
             WRITE_CSR_FIELD<XLEN>(state, MSTATUS, "mie", mie_val);
 
-            if (state->getCore()->hasHypervisor())
+            if (state->hasHypervisor())
             {
                 // Previous virtualization mode
                 const uint64_t mpv_val = prev_virt_mode;

--- a/core/PegasusCore.cpp
+++ b/core/PegasusCore.cpp
@@ -2,7 +2,6 @@
 #include "system/PegasusSystem.hpp"
 #include "system/SystemCallEmulator.hpp"
 #include "system/ReservationMemory.hpp"
-#include "include/gen/CSRBitMasks32.hpp"
 
 #include "sparta/simulation/ResourceTreeNode.hpp"
 #include "sparta/utils/LogUtils.hpp"
@@ -42,44 +41,6 @@ namespace pegasus
         return priv_modes;
     }
 
-    uint32_t getXlenFromIsaString(const std::string & isa_string)
-    {
-        if (isa_string.find("32") != std::string::npos)
-        {
-            return 32;
-        }
-        else if (isa_string.find("64") != std::string::npos)
-        {
-            return 64;
-        }
-        else
-        {
-            sparta_assert(false, "Failed to determine XLEN from ISA string: " << isa_string);
-        }
-    }
-
-    bool PegasusCore::validateISAString_(std::string & unsupportedExt)
-    {
-        const auto & supported_exts =
-            (xlen_ == 64) ? supported_rv64_extensions_ : supported_rv32_extensions_;
-
-        const auto hasExtension = [&](const std::string & ext) {
-            return std::find(supported_exts.begin(), supported_exts.end(), ext)
-                   != supported_exts.end();
-        };
-
-        for (const auto & ext : extension_manager_.getEnabledExtensions(false))
-        {
-            if (!hasExtension(ext.first))
-            {
-                unsupportedExt = ext.first;
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     PegasusCore::PegasusCore(sparta::TreeNode* core_tn, const PegasusCoreParameters* p) :
         sparta::Unit(core_tn),
         core_id_(p->core_id),
@@ -99,19 +60,14 @@ namespace pegasus
             PegasusSimParameters::getParameter<bool>(core_tn, "enable_syscall_emulation")),
         arch_name_(p->arch),
         profile_(p->profile),
-        isa_string_(p->isa),
-        supported_priv_modes_(initSupportedPrivilegeModes(p->priv)),
-        xlen_(getXlenFromIsaString(isa_string_)),
+        supported_exts_(p->isa),
         supported_rv64_extensions_(SUPPORTED_RV64_EXTS),
         supported_rv32_extensions_(SUPPORTED_RV32_EXTS),
+        supported_priv_modes_(initSupportedPrivilegeModes(p->priv)),
         supported_trap_modes_(p->supported_trap_modes),
         misalignment_support_(p->misalignment_support),
         isa_file_path_(p->isa_file_path),
         uarch_file_path_(p->uarch_file_path),
-        extension_manager_(mavis::extension_manager::riscv::RISCVExtensionManager::fromISA(
-            isa_string_, isa_file_path_ + std::string("/riscv_isa_spec.json"), isa_file_path_)),
-        hypervisor_enabled_(extension_manager_.isEnabled("h")),
-        zicntr_enabled_(extension_manager_.isEnabled("zicntr")),
         reservations_(num_harts_),
         inst_handlers_(syscall_emulation_enabled_)
     {
@@ -124,10 +80,6 @@ namespace pegasus
                 hart_tn = new sparta::ResourceTreeNode(core_tn, hart_name, "harts", hart_idx,
                                                        "Hart State", &state_factory_));
 
-            // Set XLEN
-            hart_tn->getChildAs<sparta::ParameterBase>("params.xlen")
-                ->setValueFromString(std::to_string(xlen_));
-
             // Set hart_id if not explicitly set
             auto hart_id = hart_tn->getChildAs<sparta::ParameterBase>("params.hart_id");
             if (hart_id->isDefault())
@@ -136,8 +88,7 @@ namespace pegasus
             }
 
             // Set path to register JSONs (from "arch")
-            const std::string reg_json_file_path =
-                uarch_file_path_ + "/" + arch_name_ + "/rv" + std::to_string(xlen_) + "/gen";
+            const std::string reg_json_file_path = uarch_file_path_ + "/" + arch_name_;
             hart_tn->getChildAs<sparta::ParameterBase>("params.reg_json_file_path")
                 ->setValueFromString(reg_json_file_path);
 
@@ -160,22 +111,6 @@ namespace pegasus
             tns_to_delete_.emplace_back(new sparta::ResourceTreeNode(
                 hart_tn, "exception", sparta::TreeNode::GROUP_NAME_NONE,
                 sparta::TreeNode::GROUP_IDX_NONE, "Exception Unit", &exception_factory_));
-        }
-
-        sparta_assert(xlen_ == extension_manager_.getXLEN());
-
-        if (profile_.empty() == false)
-        {
-            extension_manager_.setProfile(profile_);
-        }
-        extension_manager_.setISA(isa_string_);
-
-        std::string unsupportedExt;
-        if (!validateISAString_(unsupportedExt))
-        {
-            sparta_assert(false,
-                          "ISA extension: " << unsupportedExt
-                                            << " is not supported in isa_string: " << isa_string_);
         }
 
         sparta::StartupEvent(core_tn, CREATE_SPARTA_HANDLER(PegasusCore, advanceSim_));
@@ -256,36 +191,6 @@ namespace pegasus
         state->getSimState()->sim_stopped = false;
         threads_running_.set(0);
     }
-
-    template <typename XLEN> uint32_t PegasusCore::getMisaExtFieldValue() const
-    {
-        uint32_t ext_val = 0;
-        for (char ext = 'a'; ext <= 'z'; ++ext)
-        {
-            const std::string ext_str = std::string(1, ext);
-            if (extension_manager_.isEnabled(ext_str))
-            {
-                ext_val |= 1 << getCsrBitRange<XLEN>(MISA, ext_str.c_str()).first;
-            }
-        }
-
-        // FIXME: Assume both User and Supervisor mode are supported
-        if constexpr (std::is_same_v<XLEN, RV64>)
-        {
-            ext_val |= 1 << CSR_64::MISA::u::high_bit;
-            ext_val |= 1 << CSR_64::MISA::s::high_bit;
-        }
-        else
-        {
-            ext_val |= 1 << CSR_32::MISA::u::high_bit;
-            ext_val |= 1 << CSR_32::MISA::s::high_bit;
-        }
-
-        return ext_val;
-    }
-
-    template uint32_t PegasusCore::getMisaExtFieldValue<RV32>() const;
-    template uint32_t PegasusCore::getMisaExtFieldValue<RV64>() const;
 
     // This method will execute a single thread for up to X instructions
     // where X is the quantum for that thread. The cycle count of all threads

--- a/core/PegasusCore.cpp
+++ b/core/PegasusCore.cpp
@@ -131,7 +131,7 @@ namespace pegasus
         DLOG("Stopping simulation for all harts");
         for (auto & [hart_idx, thread] : threads_)
         {
-            thread->stopSim(exit_code);
+            thread->setSimStopped(true, exit_code);
             threads_running_.reset(hart_idx);
         }
 

--- a/core/PegasusCore.cpp
+++ b/core/PegasusCore.cpp
@@ -313,42 +313,8 @@ namespace pegasus
 
     template <bool IS_UNIT_TEST> bool PegasusCore::compare(const PegasusCore* core) const
     {
-        if constexpr (IS_UNIT_TEST)
-        {
-            EXPECT_EQUAL(xlen_, core->xlen_);
-        }
-        else if (xlen_ != core->xlen_)
-        {
-            return false;
-        }
-
-        auto has_hypervisor = hasHypervisor();
-        auto other_has_hypervisor = core->hasHypervisor();
-        if constexpr (IS_UNIT_TEST)
-        {
-            EXPECT_EQUAL(has_hypervisor, other_has_hypervisor);
-        }
-        else if (has_hypervisor != other_has_hypervisor)
-        {
-            return false;
-        }
-
-        auto misa_ext_field_value =
-            xlen_ == 32 ? getMisaExtFieldValue<uint32_t>() : getMisaExtFieldValue<uint64_t>();
-
-        auto other_misa_ext_field_value = core->getXlen() == 32
-                                              ? core->getMisaExtFieldValue<uint32_t>()
-                                              : core->getMisaExtFieldValue<uint64_t>();
-
-        if constexpr (IS_UNIT_TEST)
-        {
-            EXPECT_EQUAL(misa_ext_field_value, other_misa_ext_field_value);
-        }
-        else if (misa_ext_field_value != other_misa_ext_field_value)
-        {
-            return false;
-        }
-
+        // TODO?
+        (void)core;
         return true;
     }
 

--- a/core/PegasusCore.cpp
+++ b/core/PegasusCore.cpp
@@ -311,13 +311,6 @@ namespace pegasus
         state->unregisterWaitOnReservationSet();
     }
 
-    template <bool IS_UNIT_TEST> bool PegasusCore::compare(const PegasusCore* core) const
-    {
-        // TODO?
-        (void)core;
-        return true;
-    }
-
     void PegasusCore::makeReservation(HartId hart_id, Addr paddr)
     {
         for (uint32_t hart_id = 0; hart_id < num_harts_; ++hart_id)
@@ -348,6 +341,51 @@ namespace pegasus
         {
             current_memory_view_ = system_->getSystemMemory();
         }
+    }
+
+    template <bool IS_UNIT_TEST> bool PegasusCore::compare(const PegasusCore* core) const
+    {
+        const auto num_harts = getNumThreads();
+        const auto other_num_harts = core->getNumThreads();
+        if constexpr (IS_UNIT_TEST)
+        {
+            EXPECT_EQUAL(num_harts, other_num_harts);
+        }
+        else if (num_harts != other_num_harts)
+        {
+            return false;
+        }
+
+        for (uint32_t hart_idx = 0; hart_idx < num_harts; ++hart_idx)
+        {
+            const auto resv = getReservation(hart_idx);
+            const auto other_resv = core->getReservation(hart_idx);
+
+            if constexpr (IS_UNIT_TEST)
+            {
+                EXPECT_EQUAL(resv.isValid(), other_resv.isValid());
+                if (resv.isValid())
+                {
+                    EXPECT_EQUAL(resv, other_resv);
+                }
+            }
+            else
+            {
+                if (resv.isValid() != other_resv.isValid())
+                {
+                    return false;
+                }
+                if (resv.isValid())
+                {
+                    if (resv != other_resv)
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
     }
 
     template bool PegasusCore::compare<false>(const PegasusCore* core) const;

--- a/core/PegasusCore.hpp
+++ b/core/PegasusCore.hpp
@@ -43,7 +43,8 @@ namespace pegasus
             PARAMETER(uint32_t, num_harts, 1, "Number of harts (hardware threads)")
             PARAMETER(std::string, arch, "default", "Architecture name")
             PARAMETER(std::string, profile, "", "RISC-V profile (defined in Mavis)")
-            PARAMETER(std::string, isa, std::string("rv64") + DEFAULT_ISA_STR, "ISA string")
+            PARAMETER(std::string, isa, std::string("rv64") + DEFAULT_ISA_STR,
+                      "Default ISA string for all HARTs on this core.")
             PARAMETER(std::string, priv, "msu", "Privilege modes supported")
             PARAMETER(std::string, isa_file_path, "mavis_json", "Where are the Mavis isa files?")
             PARAMETER(std::string, uarch_file_path, "arch", "Where are the Pegasus uarch files?")
@@ -84,6 +85,17 @@ namespace pegasus
 
         bool isSystemCallEmulationEnabled() const { return syscall_emulation_enabled_; }
 
+        bool isExtensionSupported(const uint64_t xlen, const std::string & ext) const
+        {
+            const auto & supported_exts =
+                (xlen == 64) ? supported_rv64_extensions_ : supported_rv32_extensions_;
+            const auto hasExtension = [&](const std::string & ext) {
+                return std::find(supported_exts.begin(), supported_exts.end(), ext)
+                       != supported_exts.end();
+            };
+            return hasExtension(ext);
+        }
+
         bool isPrivilegeModeSupported(const PrivMode mode) const
         {
             return supported_priv_modes_.contains(mode);
@@ -95,17 +107,7 @@ namespace pegasus
             return std::find(modes.begin(), modes.end(), static_cast<int>(mode)) != modes.end();
         }
 
-        uint64_t getXlen() const { return xlen_; }
-
         bool isMisalignmentSupported() const { return misalignment_support_; }
-
-        // Is the "H" extension enabled?
-        bool hasHypervisor() const { return hypervisor_enabled_; }
-
-        // Is the "Zicntr" extension enabled?
-        bool hasZicntr() const { return zicntr_enabled_; }
-
-        template <typename XLEN> uint32_t getMisaExtFieldValue() const;
 
         using Reservation = sparta::utils::ValidValue<Addr>;
 
@@ -121,8 +123,6 @@ namespace pegasus
         void clearReservation(HartId hart_id);
 
         const InstHandlers* getInstHandlers() const { return &inst_handlers_; }
-
-        const std::string & getISAString() const { return isa_string_; }
 
         void unpauseHart(HartId hart_id) { threads_running_.set(hart_id); }
 
@@ -190,18 +190,15 @@ namespace pegasus
         // RISC-V profile
         const std::string profile_;
 
-        // ISA string
-        const std::string isa_string_;
-
-        // Supported privilege modes
-        const std::unordered_set<PrivMode> supported_priv_modes_;
-
-        // XLEN (either 32 or 64 bit)
-        uint64_t xlen_ = 64;
+        // Supported extensions (formatted as an ISA string)
+        const std::string supported_exts_;
 
         // Supported ISA string
         const std::vector<std::string> supported_rv64_extensions_;
         const std::vector<std::string> supported_rv32_extensions_;
+
+        // Supported privilege modes
+        const std::unordered_set<PrivMode> supported_priv_modes_;
 
         // Supported Trap Modes
         const std::vector<int> supported_trap_modes_;
@@ -214,17 +211,6 @@ namespace pegasus
 
         // Path to Pegasus uarch JSONs
         const std::string uarch_file_path_;
-
-        // Mavis extension manager
-        mavis::extension_manager::riscv::RISCVExtensionManager extension_manager_;
-
-        inline bool validateISAString_(std::string & unsupportedExt);
-
-        //! Do we have hypervisor?
-        const bool hypervisor_enabled_;
-
-        //! Do we have the counter extension?
-        const bool zicntr_enabled_;
 
         //! LR/SC Reservations
         std::vector<Reservation> reservations_;

--- a/core/PegasusCore.hpp
+++ b/core/PegasusCore.hpp
@@ -89,7 +89,8 @@ namespace pegasus
         {
             const auto & supported_exts =
                 (xlen == 64) ? supported_rv64_extensions_ : supported_rv32_extensions_;
-            const auto hasExtension = [&](const std::string & ext) {
+            const auto hasExtension = [&](const std::string & ext)
+            {
                 return std::find(supported_exts.begin(), supported_exts.end(), ext)
                        != supported_exts.end();
             };

--- a/core/PegasusCore.hpp
+++ b/core/PegasusCore.hpp
@@ -223,6 +223,5 @@ namespace pegasus
 
         // ReservationMemory
         std::unique_ptr<ReservationMemory> reservation_memory_bmi_;
-        ;
     };
 } // namespace pegasus

--- a/core/PegasusCore.hpp
+++ b/core/PegasusCore.hpp
@@ -89,8 +89,7 @@ namespace pegasus
         {
             const auto & supported_exts =
                 (xlen == 64) ? supported_rv64_extensions_ : supported_rv32_extensions_;
-            const auto hasExtension = [&](const std::string & ext)
-            {
+            const auto hasExtension = [&](const std::string & ext) {
                 return std::find(supported_exts.begin(), supported_exts.end(), ext)
                        != supported_exts.end();
             };

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -27,6 +27,22 @@
 
 namespace pegasus
 {
+    uint32_t getXlenFromIsaString(const std::string & isa_string)
+    {
+        if (isa_string.find("32") != std::string::npos)
+        {
+            return 32;
+        }
+        else if (isa_string.find("64") != std::string::npos)
+        {
+            return 64;
+        }
+        else
+        {
+            sparta_assert(false, "Failed to determine XLEN from ISA string: " << isa_string);
+        }
+    }
+
     uint64_t getInstLimit(sparta::TreeNode* rtn, uint64_t ilimit)
     {
         auto extension = sparta::notNull(rtn->createExtension("sim"));
@@ -60,7 +76,6 @@ namespace pegasus
         sparta::Unit(hart_tn),
         hart_id_(p->hart_id),
         vlen_(p->vlen),
-        xlen_(p->xlen),
         reg_json_file_path_(p->reg_json_file_path),
         ilimit_(getInstLimit(hart_tn->getRoot(), p->ilimit)),
         quantum_(p->quantum),
@@ -75,6 +90,7 @@ namespace pegasus
         isa_string_(hart_tn->getParent()
                         ->getChildAs<sparta::ParameterSet>("params")
                         ->getParameterValueAs<std::string>("isa")),
+        xlen_(getXlenFromIsaString(isa_string_)),
         isa_file_path_(hart_tn->getParent()
                            ->getChildAs<sparta::ParameterSet>("params")
                            ->getParameterValueAs<std::string>("isa_file_path")),
@@ -86,21 +102,40 @@ namespace pegasus
                              ->getParameterValueAs<std::string>("uarch_file_path")),
         extension_manager_(mavis::extension_manager::riscv::RISCVExtensionManager::fromISA(
             isa_string_, isa_file_path_ + std::string("/riscv_isa_spec.json"), isa_file_path_)),
+        hypervisor_enabled_(extension_manager_.isEnabled("h")),
+        zicntr_enabled_(extension_manager_.isEnabled("zicntr")),
         inst_logger_(hart_tn, "inst", "Pegasus Instruction Logger"),
         stf_valid_logger_(hart_tn, "stf_valid", "Pegasus STF Validator Logger"),
         finish_action_group_("finish_inst"),
         stop_sim_action_group_("stop_sim"),
         pause_sim_action_group_("pause_sim")
     {
+        const std::string profile = hart_tn->getParent()
+                                        ->getChildAs<sparta::ParameterSet>("params")
+                                        ->getParameterValueAs<std::string>("profile");
+        if (profile.empty() == false)
+        {
+            extension_manager_.setProfile(profile);
+        }
+
+        const std::string init_isa = p->isa;
+        if (init_isa.empty() == false)
+        {
+            isa_string_ = p->isa;
+            extension_manager_.setISA(isa_string_);
+        }
+
         // Set up register sets
-        int_rset_ = RegisterSet::create(hart_tn, reg_json_file_path_ + std::string("/reg_int.json"),
+        const std::string reg_json_file_path =
+            reg_json_file_path_ + "/rv" + std::to_string(xlen_) + "/gen";
+        int_rset_ = RegisterSet::create(hart_tn, reg_json_file_path + std::string("/reg_int.json"),
                                         "int_regs");
-        fp_rset_ = RegisterSet::create(hart_tn, reg_json_file_path_ + std::string("/reg_fp.json"),
+        fp_rset_ = RegisterSet::create(hart_tn, reg_json_file_path + std::string("/reg_fp.json"),
                                        "fp_regs");
         const std::string vec_reg_json = "/reg_vec" + std::to_string(vlen_) + ".json";
-        vec_rset_ = RegisterSet::create(hart_tn, reg_json_file_path_ + vec_reg_json, "vec_regs");
+        vec_rset_ = RegisterSet::create(hart_tn, reg_json_file_path + vec_reg_json, "vec_regs");
         csr_rset_ = RegisterSet::create(
-            hart_tn, reg_json_file_path_ + std::string("/reg_csr_hart.json"), "csr_regs");
+            hart_tn, reg_json_file_path + std::string("/reg_csr_hart.json"), "csr_regs");
 
         auto add_registers = [this](const auto & reg_set)
         {
@@ -247,11 +282,22 @@ namespace pegasus
 
     void PegasusState::onBindTreeLate_()
     {
+        // Validate the ISA string
+        for (const auto & ext : extension_manager_.getEnabledExtensions(false))
+        {
+            if (false == pegasus_core_->isExtensionSupported(xlen_, ext.first))
+            {
+                sparta_assert(false, "ISA extension: " << ext.first
+                                                       << " is not supported in isa_string: "
+                                                       << isa_string_);
+            }
+        }
+
         // Set up translation
         if (xlen_ == 64)
         {
             updateTranslationMode<RV64>(translate_types::TranslationStage::SUPERVISOR);
-            if (pegasus_core_->hasHypervisor())
+            if (hasHypervisor())
             {
                 updateTranslationMode<RV64>(translate_types::TranslationStage::VIRTUAL_SUPERVISOR);
                 updateTranslationMode<RV64>(translate_types::TranslationStage::GUEST);
@@ -260,7 +306,7 @@ namespace pegasus
         else
         {
             updateTranslationMode<RV32>(translate_types::TranslationStage::SUPERVISOR);
-            if (pegasus_core_->hasHypervisor())
+            if (hasHypervisor())
             {
                 updateTranslationMode<RV32>(translate_types::TranslationStage::VIRTUAL_SUPERVISOR);
                 updateTranslationMode<RV32>(translate_types::TranslationStage::GUEST);
@@ -458,6 +504,36 @@ namespace pegasus
 
         initCsrEnabledState_();
     }
+
+    template <typename XLEN> uint32_t PegasusState::getMisaExtFieldValue() const
+    {
+        uint32_t ext_val = 0;
+        for (char ext = 'a'; ext <= 'z'; ++ext)
+        {
+            const std::string ext_str = std::string(1, ext);
+            if (extension_manager_.isEnabled(ext_str))
+            {
+                ext_val |= 1 << getCsrBitRange<XLEN>(MISA, ext_str.c_str()).first;
+            }
+        }
+
+        // FIXME: Assume both User and Supervisor mode are supported
+        if constexpr (std::is_same_v<XLEN, RV64>)
+        {
+            ext_val |= 1 << CSR_64::MISA::u::high_bit;
+            ext_val |= 1 << CSR_64::MISA::s::high_bit;
+        }
+        else
+        {
+            ext_val |= 1 << CSR_32::MISA::u::high_bit;
+            ext_val |= 1 << CSR_32::MISA::s::high_bit;
+        }
+
+        return ext_val;
+    }
+
+    template uint32_t PegasusState::getMisaExtFieldValue<RV32>() const;
+    template uint32_t PegasusState::getMisaExtFieldValue<RV64>() const;
 
     void PegasusState::enableInteractiveMode()
     {
@@ -693,7 +769,7 @@ namespace pegasus
         // for now just assume each inst takes 1 cycle
         ++sim_state_.cycles;
 
-        if (pegasus_core_->hasZicntr())
+        if (hasZicntr())
         {
             incrInstretCsrs_<XLEN>();
             incrCycleCsrs_<XLEN>();
@@ -723,13 +799,38 @@ namespace pegasus
 
     template <bool IS_UNIT_TEST> bool PegasusState::compare(const PegasusState* state) const
     {
-        auto xlen = getXlen();
         auto other_xlen = state->getXlen();
         if constexpr (IS_UNIT_TEST)
         {
-            EXPECT_EQUAL(xlen, other_xlen);
+            EXPECT_EQUAL(xlen_, other_xlen);
         }
-        else if (xlen != other_xlen)
+        else if (xlen_ != other_xlen)
+        {
+            return false;
+        }
+
+        auto has_hypervisor = hasHypervisor();
+        auto other_has_hypervisor = state->hasHypervisor();
+        if constexpr (IS_UNIT_TEST)
+        {
+            EXPECT_EQUAL(has_hypervisor, other_has_hypervisor);
+        }
+        else if (has_hypervisor != other_has_hypervisor)
+        {
+            return false;
+        }
+
+        auto misa_ext_field_value =
+            xlen_ == 32 ? getMisaExtFieldValue<uint32_t>() : getMisaExtFieldValue<uint64_t>();
+
+        auto other_misa_ext_field_value = getXlen() == 32 ? state->getMisaExtFieldValue<uint32_t>()
+                                                          : state->getMisaExtFieldValue<uint64_t>();
+
+        if constexpr (IS_UNIT_TEST)
+        {
+            EXPECT_EQUAL(misa_ext_field_value, other_misa_ext_field_value);
+        }
+        else if (misa_ext_field_value != other_misa_ext_field_value)
         {
             return false;
         }
@@ -867,7 +968,7 @@ namespace pegasus
     {
         std::cout << "Stopping hart" << std::dec << hart_id_ << std::endl;
 
-        if (pegasus_core_->hasZicntr())
+        if (hasZicntr())
         {
             if (xlen_ == 64)
             {
@@ -1087,7 +1188,7 @@ namespace pegasus
                 const uint64_t xlen_val = 2;
                 POKE_CSR_FIELD<RV64>(this, MISA, "mxl", xlen_val);
 
-                const uint32_t ext_val = pegasus_core_->getMisaExtFieldValue<RV64>();
+                const uint32_t ext_val = getMisaExtFieldValue<RV64>();
                 POKE_CSR_FIELD<RV64>(this, MISA, "extensions", ext_val);
 
                 // Initialize MSTATUS/STATUS with User and Supervisor mode XLEN
@@ -1095,7 +1196,7 @@ namespace pegasus
                 POKE_CSR_FIELD<RV64>(this, MSTATUS, "sxl", xlen_val);
                 POKE_CSR_FIELD<RV64>(this, SSTATUS, "uxl", xlen_val);
 
-                if (pegasus_core_->hasHypervisor())
+                if (hasHypervisor())
                 {
                     POKE_CSR_FIELD<RV64>(this, VSSTATUS, "uxl", xlen_val);
                 }
@@ -1107,7 +1208,7 @@ namespace pegasus
                 const uint32_t xlen_val = 1;
                 POKE_CSR_FIELD<RV32>(this, MISA, "mxl", xlen_val);
 
-                const uint32_t ext_val = pegasus_core_->getMisaExtFieldValue<RV32>();
+                const uint32_t ext_val = getMisaExtFieldValue<RV32>();
                 POKE_CSR_FIELD<RV32>(this, MISA, "extensions", ext_val);
             }
 

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -276,6 +276,10 @@ namespace pegasus
 
     void PegasusState::onBindTreeLate_()
     {
+        // Make sure privilege mode at boot is supported
+        sparta_assert(pegasus_core_->isPrivilegeModeSupported(priv_mode_),
+                      "Privilege mode is not supported: " << priv_mode_);
+
         // Validate the ISA string
         for (const auto & ext : extension_manager_.getEnabledExtensions(false))
         {

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -125,6 +125,8 @@ namespace pegasus
             extension_manager_.setISA(isa_string_);
         }
 
+        setPcAlignment_(isCompressionEnabled() ? 2 : 4);
+
         // Set up register sets
         const std::string reg_json_file_path =
             reg_json_file_path_ + "/rv" + std::to_string(xlen_) + "/gen";
@@ -155,6 +157,9 @@ namespace pegasus
         add_registers(fp_rset_);
         add_registers(vec_rset_);
         add_registers(csr_rset_);
+
+        csr_enabled_state_.resize(csr_rset_->getNumRegisters(), true);
+        initCsrEnabledState_();
 
         // Add CSR callbacks and increment PC Action
         const bool CHECK_ILIMIT = ilimit_ > 0;
@@ -196,17 +201,6 @@ namespace pegasus
         {
             sparta_assert(false, "Unsupported XLEN");
         }
-
-        if (isCompressionEnabled())
-        {
-            setPcAlignment_(2);
-        }
-        else
-        {
-            setPcAlignment_(4);
-        }
-
-        initCsrEnabledState_();
 
         // Add increment PC Action to finish ActionGroup
         finish_action_group_.addAction(increment_pc_action_);
@@ -493,14 +487,10 @@ namespace pegasus
     {
         extension_manager_.switchMavisContext(*mavis_.get());
 
-        if (isCompressionEnabled())
-        {
-            setPcAlignment_(2);
-        }
-        else
-        {
-            setPcAlignment_(4);
-        }
+        hypervisor_enabled_ = extension_manager_.isEnabled("h");
+        zicntr_enabled_ = extension_manager_.isEnabled("zicntr");
+
+        setPcAlignment_(isCompressionEnabled() ? 2 : 4);
 
         initCsrEnabledState_();
     }
@@ -799,53 +789,6 @@ namespace pegasus
 
     template <bool IS_UNIT_TEST> bool PegasusState::compare(const PegasusState* state) const
     {
-        auto other_xlen = state->getXlen();
-        if constexpr (IS_UNIT_TEST)
-        {
-            EXPECT_EQUAL(xlen_, other_xlen);
-        }
-        else if (xlen_ != other_xlen)
-        {
-            return false;
-        }
-
-        auto has_hypervisor = hasHypervisor();
-        auto other_has_hypervisor = state->hasHypervisor();
-        if constexpr (IS_UNIT_TEST)
-        {
-            EXPECT_EQUAL(has_hypervisor, other_has_hypervisor);
-        }
-        else if (has_hypervisor != other_has_hypervisor)
-        {
-            return false;
-        }
-
-        auto misa_ext_field_value =
-            xlen_ == 32 ? getMisaExtFieldValue<uint32_t>() : getMisaExtFieldValue<uint64_t>();
-
-        auto other_misa_ext_field_value = getXlen() == 32 ? state->getMisaExtFieldValue<uint32_t>()
-                                                          : state->getMisaExtFieldValue<uint64_t>();
-
-        if constexpr (IS_UNIT_TEST)
-        {
-            EXPECT_EQUAL(misa_ext_field_value, other_misa_ext_field_value);
-        }
-        else if (misa_ext_field_value != other_misa_ext_field_value)
-        {
-            return false;
-        }
-
-        auto stop_sim_on_wfi = getStopSimOnWfi();
-        auto other_stop_sim_on_wfi = state->getStopSimOnWfi();
-        if constexpr (IS_UNIT_TEST)
-        {
-            EXPECT_EQUAL(stop_sim_on_wfi, other_stop_sim_on_wfi);
-        }
-        else if (stop_sim_on_wfi != other_stop_sim_on_wfi)
-        {
-            return false;
-        }
-
         auto pc = getPc();
         auto other_pc = state->getPc();
         if constexpr (IS_UNIT_TEST)
@@ -897,6 +840,51 @@ namespace pegasus
             EXPECT_EQUAL(curr_excp, other_curr_excp);
         }
         else if (curr_excp != other_curr_excp)
+        {
+            return false;
+        }
+
+        auto other_xlen = state->getXlen();
+        if constexpr (IS_UNIT_TEST)
+        {
+            EXPECT_EQUAL(xlen_, other_xlen);
+        }
+        else if (xlen_ != other_xlen)
+        {
+            return false;
+        }
+
+        auto has_hypervisor = hasHypervisor();
+        auto other_has_hypervisor = state->hasHypervisor();
+        if constexpr (IS_UNIT_TEST)
+        {
+            EXPECT_EQUAL(has_hypervisor, other_has_hypervisor);
+        }
+        else if (has_hypervisor != other_has_hypervisor)
+        {
+            return false;
+        }
+
+        auto has_zicntr = hasZicntr();
+        auto other_has_zicntr = state->hasZicntr();
+        if constexpr (IS_UNIT_TEST)
+        {
+            EXPECT_EQUAL(has_zicntr, other_has_zicntr);
+        }
+        else if (has_zicntr != other_has_zicntr)
+        {
+            return false;
+        }
+
+        auto misa_ext_field_value =
+            xlen_ == 32 ? getMisaExtFieldValue<uint32_t>() : getMisaExtFieldValue<uint64_t>();
+        auto other_misa_ext_field_value = getXlen() == 32 ? state->getMisaExtFieldValue<uint32_t>()
+                                                          : state->getMisaExtFieldValue<uint64_t>();
+        if constexpr (IS_UNIT_TEST)
+        {
+            EXPECT_EQUAL(misa_ext_field_value, other_misa_ext_field_value);
+        }
+        else if (misa_ext_field_value != other_misa_ext_field_value)
         {
             return false;
         }
@@ -1277,25 +1265,15 @@ namespace pegasus
 
     void PegasusState::initCsrEnabledState_()
     {
-        const auto & extensionManager = getExtensionManager();
-
-        // Enable all register by default
-        csr_enabled_state_.resize(csr_rset_->getNumRegisters(), true);
-
         // Check for disabled extensions
         for (auto & dep : csr_rset_->getRegisterExtensionDep())
         {
-            auto reg = dep.first;
-            auto extensions = dep.second;
+            const auto & reg = dep.first;
+            const auto & extensions = dep.second;
 
-            for (auto ext : extensions)
-            {
-                if (!extensionManager.isEnabled(ext))
-                {
-                    csr_enabled_state_[reg] = false;
-                    break;
-                }
-            }
+            csr_enabled_state_[reg] =
+                std::all_of(extensions.begin(), extensions.end(), [this](const std::string & ext)
+                            { return extension_manager_.isEnabled(ext); });
         }
     }
 

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -1275,9 +1275,12 @@ namespace pegasus
             const auto & reg = dep.first;
             const auto & extensions = dep.second;
 
-            csr_enabled_state_[reg] =
-                std::all_of(extensions.begin(), extensions.end(), [this](const std::string & ext)
-                            { return extension_manager_.isEnabled(ext); });
+            csr_enabled_state_[reg] = std::all_of(extensions.begin(), extensions.end(),
+                [this](const std::string & ext)
+                {
+                    return extension_manager_.isEnabled(ext);
+                }
+            );
         }
     }
 

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -278,7 +278,7 @@ namespace pegasus
     {
         // Make sure privilege mode at boot is supported
         sparta_assert(pegasus_core_->isPrivilegeModeSupported(priv_mode_),
-                      "Privilege mode is not supported: " << priv_mode_);
+                      "Attempting to change privilege mode to an unsupported mode: " << priv_mode_);
 
         // Validate the ISA string
         for (const auto & ext : extension_manager_.getEnabledExtensions(false))

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -777,7 +777,7 @@ namespace pegasus
                 std::cout << "Reached instruction limit (" << std::dec << ilimit_
                           << "), stopping simulation." << std::endl;
                 const uint64_t exit_code = 0;
-                stopSim(exit_code);
+                setSimStopped(true, exit_code);
             }
         }
 
@@ -956,31 +956,44 @@ namespace pegasus
         return true;
     }
 
-    void PegasusState::stopSim(const int64_t exit_code)
+    void PegasusState::setSimStopped(bool sim_stopped, const int64_t exit_code)
     {
-        std::cout << "Stopping hart" << std::dec << hart_id_ << std::endl;
-
-        if (hasZicntr())
+        sim_state_.sim_stopped = sim_stopped;
+        if (sim_stopped)
         {
-            if (xlen_ == 64)
+            std::cout << "Stopping hart" << std::dec << hart_id_ << std::endl;
+
+            if (hasZicntr())
             {
-                std::cout << "\tCYCLE: " << getCsrRegister(CYCLE)->dmiRead<RV64>() << std::endl;
-                std::cout << "\tTIME: " << getCsrRegister(TIME)->dmiRead<RV64>() << std::endl;
-                std::cout << "\tINSTRET: " << getCsrRegister(INSTRET)->dmiRead<RV64>() << std::endl;
+                if (xlen_ == 64)
+                {
+                    std::cout << "\tCYCLE: " << getCsrRegister(CYCLE)->dmiRead<RV64>() << std::endl;
+                    std::cout << "\tTIME: " << getCsrRegister(TIME)->dmiRead<RV64>() << std::endl;
+                    std::cout << "\tINSTRET: " << getCsrRegister(INSTRET)->dmiRead<RV64>()
+                              << std::endl;
+                }
+                else
+                {
+                    std::cout << "\tCYCLE: " << getCsrRegister(CYCLE)->dmiRead<RV32>() << std::endl;
+                    std::cout << "\tTIME: " << getCsrRegister(TIME)->dmiRead<RV32>() << std::endl;
+                    std::cout << "\tINSTRET: " << getCsrRegister(INSTRET)->dmiRead<RV32>()
+                              << std::endl;
+                }
             }
-            else
-            {
-                std::cout << "\tCYCLE: " << getCsrRegister(CYCLE)->dmiRead<RV32>() << std::endl;
-                std::cout << "\tTIME: " << getCsrRegister(TIME)->dmiRead<RV32>() << std::endl;
-                std::cout << "\tINSTRET: " << getCsrRegister(INSTRET)->dmiRead<RV32>() << std::endl;
-            }
+
+            sim_state_.workload_exit_code = exit_code;
+            sim_state_.test_passed = (exit_code == 0) ? true : false;
+
+            finish_action_group_.setNextActionGroup(&stop_sim_action_group_);
         }
+        else
+        {
+            (void)exit_code;
+            sim_state_.workload_exit_code = 0;
+            sim_state_.test_passed = true;
 
-        sim_state_.workload_exit_code = exit_code;
-        sim_state_.test_passed = (exit_code == 0) ? true : false;
-        sim_state_.sim_stopped = true;
-
-        finish_action_group_.setNextActionGroup(&stop_sim_action_group_);
+            finish_action_group_.setNextActionGroup(fetch_unit_->getActionGroup());
+        }
     }
 
     template <typename XLEN> XLEN PegasusState::emulateSystemCall()

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -1275,12 +1275,9 @@ namespace pegasus
             const auto & reg = dep.first;
             const auto & extensions = dep.second;
 
-            csr_enabled_state_[reg] = std::all_of(extensions.begin(), extensions.end(),
-                [this](const std::string & ext)
-                {
-                    return extension_manager_.isEnabled(ext);
-                }
-            );
+            csr_enabled_state_[reg] =
+                std::all_of(extensions.begin(), extensions.end(), [this](const std::string & ext)
+                            { return extension_manager_.isEnabled(ext); });
         }
     }
 

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -125,7 +125,7 @@ namespace pegasus
             extension_manager_.setISA(isa_string_);
         }
 
-        setPcAlignment_(isCompressionEnabled() ? 2 : 4);
+        setPcAlignment_();
 
         // Set up register sets
         const std::string reg_json_file_path =
@@ -157,9 +157,6 @@ namespace pegasus
         add_registers(fp_rset_);
         add_registers(vec_rset_);
         add_registers(csr_rset_);
-
-        csr_enabled_state_.resize(csr_rset_->getNumRegisters(), true);
-        initCsrEnabledState_();
 
         // Add CSR callbacks and increment PC Action
         const bool CHECK_ILIMIT = ilimit_ > 0;
@@ -272,6 +269,8 @@ namespace pegasus
                     sparta::notNull(PegasusAllocators::getAllocators(getContainer()))
                         ->extractor_allocator,
                     this)));
+
+        updateCsrEnabledState_();
     }
 
     void PegasusState::onBindTreeLate_()
@@ -494,9 +493,9 @@ namespace pegasus
         hypervisor_enabled_ = extension_manager_.isEnabled("h");
         zicntr_enabled_ = extension_manager_.isEnabled("zicntr");
 
-        setPcAlignment_(isCompressionEnabled() ? 2 : 4);
+        setPcAlignment_();
 
-        initCsrEnabledState_();
+        updateCsrEnabledState_();
     }
 
     template <typename XLEN> uint32_t PegasusState::getMisaExtFieldValue() const
@@ -988,7 +987,9 @@ namespace pegasus
         }
         else
         {
-            (void)exit_code;
+            sparta_assert(exit_code == 0,
+                          "Exit code should not be set if simulation is being resumed. Exit code: "
+                              << std::dec << exit_code);
             sim_state_.workload_exit_code = 0;
             sim_state_.test_passed = true;
 
@@ -1280,7 +1281,7 @@ namespace pegasus
     template bool PegasusState::SimState::compare<false>(const SimState* rhs) const;
     template bool PegasusState::SimState::compare<true>(const SimState* rhs) const;
 
-    void PegasusState::initCsrEnabledState_()
+    void PegasusState::updateCsrEnabledState_()
     {
         // Check for disabled extensions
         for (auto & dep : csr_rset_->getRegisterExtensionDep())
@@ -1288,7 +1289,7 @@ namespace pegasus
             const auto & reg = dep.first;
             const auto & extensions = dep.second;
 
-            csr_enabled_state_[reg] =
+            csr_enabled_states_[reg] =
                 std::all_of(extensions.begin(), extensions.end(), [this](const std::string & ext)
                             { return extension_manager_.isEnabled(ext); });
         }

--- a/core/PegasusState.hpp
+++ b/core/PegasusState.hpp
@@ -317,12 +317,11 @@ namespace pegasus
 
         inline bool isRegEnabled(uint32_t id) const
         {
-            if (id >= csr_enabled_state_.size())
+            if (csr_enabled_states_.contains(id))
             {
-                return false;
+                return csr_enabled_states_.at(id);
             }
-
-            return csr_enabled_state_[id];
+            return true;
         }
 
         // Memory supplement for observing memory reads and writes
@@ -467,12 +466,10 @@ namespace pegasus
         //! PC alignment
         uint64_t pc_alignment_mask_ = ~(pc_alignment_ - 1);
 
-        void setPcAlignment_(uint64_t pc_alignment)
+        void setPcAlignment_()
         {
-            sparta_assert(pc_alignment == 2 || pc_alignment == 4,
-                          "Invalid PC alignment value! " << pc_alignment);
-            pc_alignment_ = pc_alignment;
-            pc_alignment_mask_ = ~(pc_alignment - 1);
+            pc_alignment_ = isCompressionEnabled() ? 2 : 4;
+            pc_alignment_mask_ = ~(pc_alignment_ - 1);
         }
 
         //! Current privilege mode
@@ -570,13 +567,9 @@ namespace pegasus
         // Cached registers by name
         std::unordered_map<std::string, sparta::Register*> registers_by_name_;
 
-        // Register enabled/disabled state
-        std::vector<bool> csr_enabled_state_;
-
-        /*!
-         *  \brief Track registers that are enabled/disabled
-         */
-        void initCsrEnabledState_();
+        // Track which CSRs are enabled/disabled
+        std::map<uint32_t, bool> csr_enabled_states_;
+        void updateCsrEnabledState_();
 
         // Observers
         std::vector<std::unique_ptr<Observer>> observers_;

--- a/core/PegasusState.hpp
+++ b/core/PegasusState.hpp
@@ -9,6 +9,7 @@
 #include "arch/gen/supportedISA.hpp"
 #include "include/PegasusTypes.hpp"
 #include "include/gen/CSRBitMasks64.hpp"
+#include "include/gen/CSRBitMasks32.hpp"
 #include "include/gen/CSRHelpers.hpp"
 
 #include "sim/PegasusAllocators.hpp"
@@ -68,6 +69,9 @@ namespace pegasus
 
             PARAMETER(uint32_t, hart_id, UINT32_MAX, "Hart ID")
             PARAMETER(char, priv_mode, 'm', "Privilege mode at boot (m, s, or u)")
+            PARAMETER(std::string, isa, "",
+                      "ISA string when hart boots. If not set, the ISA string from PegasusCore is "
+                      "used instead.")
             PARAMETER(uint32_t, vlen, 256, "Vector register size in bits (max: 1024)")
             PARAMETER(uint32_t, ilimit, 0, "Instruction limit for stopping simulation")
             PARAMETER(uint32_t, quantum, 500, "Instruction quantum size")
@@ -89,7 +93,6 @@ namespace pegasus
                       "STF validation pegasus fail on first difference detected")
 
             // Set by PegasusCore
-            HIDDEN_PARAMETER(uint32_t, xlen, 64, "XLEN (either 32 or 64 bit)")
             HIDDEN_PARAMETER(std::string, reg_json_file_path, "",
                              "Where are the Pegasus register files?")
           private:
@@ -107,6 +110,8 @@ namespace pegasus
         virtual ~PegasusState();
 
         HartId getHartId() const { return hart_id_; }
+
+        const std::string & getISAString() const { return isa_string_; }
 
         uint64_t getXlen() const;
 
@@ -246,6 +251,12 @@ namespace pegasus
         bool isExtensionEnabled(std::string ext) const { return extension_manager_.isEnabled(ext); }
 
         bool isCompressionEnabled() const { return extension_manager_.isEnabled("zca"); }
+
+        bool hasHypervisor() const { return hypervisor_enabled_; }
+
+        bool hasZicntr() const { return zicntr_enabled_; }
+
+        template <typename XLEN> uint32_t getMisaExtFieldValue() const;
 
         void enableInteractiveMode();
 
@@ -419,9 +430,6 @@ namespace pegasus
         // VLEN (128, 256, 512, 1024 or 2048 bits)
         const uint32_t vlen_;
 
-        // XLEN (either 32 or 64 bit)
-        const uint64_t xlen_ = 64;
-
         // Path to register JSONs
         const std::string reg_json_file_path_;
 
@@ -505,7 +513,12 @@ namespace pegasus
         PegasusCore* pegasus_core_ = nullptr;
 
         // ISA string
-        const std::string isa_string_;
+        std::string isa_string_;
+
+        // XLEN (either 32 or 64 bit)
+        uint64_t xlen_ = 64;
+
+        // TODO
         const std::string isa_file_path_;
 
         // Arch name
@@ -529,6 +542,12 @@ namespace pegasus
 
         // Mavis
         std::unique_ptr<MavisType> mavis_;
+
+        //! Do we have hypervisor?
+        const bool hypervisor_enabled_;
+
+        //! Do we have the counter extension?
+        const bool zicntr_enabled_;
 
         // Fetch Unit
         Fetch* fetch_unit_ = nullptr;

--- a/core/PegasusState.hpp
+++ b/core/PegasusState.hpp
@@ -367,7 +367,7 @@ namespace pegasus
 
         Exception* getExceptionUnit() const { return exception_unit_; }
 
-        void stopSim(const int64_t exit_code);
+        void setSimStopped(bool sim_stopped, const int64_t exit_code = 0);
 
         template <bool IS_UNIT_TEST = false> bool compare(const PegasusState* state) const;
 

--- a/core/PegasusState.hpp
+++ b/core/PegasusState.hpp
@@ -544,10 +544,10 @@ namespace pegasus
         std::unique_ptr<MavisType> mavis_;
 
         //! Do we have hypervisor?
-        const bool hypervisor_enabled_;
+        bool hypervisor_enabled_;
 
         //! Do we have the counter extension?
-        const bool zicntr_enabled_;
+        bool zicntr_enabled_;
 
         // Fetch Unit
         Fetch* fetch_unit_ = nullptr;

--- a/core/VecConfig.hpp
+++ b/core/VecConfig.hpp
@@ -125,10 +125,9 @@ namespace pegasus
             os << config.getLMUL() / 8 << " ";
         }
         os << "SEW: " << config.getSEW() << " ";
-        os << "VTA: " << std::boolalpha << config.getVTA() << " "
-           << "VMA: " << config.getVMA() << std::noboolalpha << " ";
-        os << "VL: " << config.getVL() << " "
-           << "VSTART: " << config.getVSTART() << "; ";
+        os << "VTA: " << std::boolalpha << config.getVTA() << " " << "VMA: " << config.getVMA()
+           << std::noboolalpha << " ";
+        os << "VL: " << config.getVL() << " " << "VSTART: " << config.getVSTART() << "; ";
         return os;
     }
 } // namespace pegasus

--- a/core/inst_handlers/i/RviInsts.cpp
+++ b/core/inst_handlers/i/RviInsts.cpp
@@ -909,7 +909,7 @@ namespace pegasus
             // Get the previous privilege mode from the MPP field of MSTATUS
             prev_priv_mode = (PrivMode)READ_CSR_FIELD<XLEN>(state, MSTATUS, "mpp");
 
-            if (state->getCore()->hasHypervisor())
+            if (state->hasHypervisor())
             {
                 // Get the previous virtual mode from the MPV field of MSTATUS
                 if constexpr (std::is_same_v<XLEN, RV64>)
@@ -1007,7 +1007,7 @@ namespace pegasus
                 // Reset SPP
                 WRITE_CSR_FIELD<XLEN>(state, SSTATUS, "spp", (XLEN)PrivMode::USER);
 
-                if (state->getCore()->hasHypervisor())
+                if (state->hasHypervisor())
                 {
                     prev_virt_mode = (bool)READ_CSR_FIELD<XLEN>(state, HSTATUS, "spvp");
                     WRITE_CSR_FIELD<XLEN>(state, HSTATUS, "spv", (XLEN)0);

--- a/core/inst_handlers/v/RvvFloatInsts.cpp
+++ b/core/inst_handlers/v/RvvFloatInsts.cpp
@@ -955,24 +955,24 @@ namespace pegasus
                 }
                 else
                 {
-                    return vfUnaryHelper<XLEN, 16, opMode,
-                                         [](auto src2) { return func_wrapper(Funcs::f16, src2); },
-                                         rm>(state, action_it);
+                    return vfUnaryHelper<XLEN, 16, opMode, [](auto src2)
+                                         { return func_wrapper(Funcs::f16, src2); }, rm>(state,
+                                                                                         action_it);
                 }
                 break;
             case 32:
-                return vfUnaryHelper<XLEN, 32, opMode,
-                                     [](auto src2) { return func_wrapper(Funcs::f32, src2); }, rm>(
-                    state, action_it);
+                return vfUnaryHelper<XLEN, 32, opMode, [](auto src2)
+                                     { return func_wrapper(Funcs::f32, src2); }, rm>(state,
+                                                                                     action_it);
 
             case 64:
                 // neither narrowing to 64 bit nor widening from 64 bit
                 if constexpr (opMode.dst != OperandMode::Mode::W
                               && opMode.src2 != OperandMode::Mode::W)
                 {
-                    return vfUnaryHelper<XLEN, 64, opMode,
-                                         [](auto src2) { return func_wrapper(Funcs::f64, src2); },
-                                         rm>(state, action_it);
+                    return vfUnaryHelper<XLEN, 64, opMode, [](auto src2)
+                                         { return func_wrapper(Funcs::f64, src2); }, rm>(state,
+                                                                                         action_it);
                 }
             default:
                 sparta_assert(false, "Unsupported SEW value");
@@ -1122,8 +1122,7 @@ namespace pegasus
         switch (vector_config->getSEW())
         {
             case 16:
-                return vfBinaryHelper<XLEN, 16, opMode,
-                                      [](auto src2, auto src1)
+                return vfBinaryHelper<XLEN, 16, opMode, [](auto src2, auto src1)
                                       {
                                           if constexpr (opMode.dst == OperandMode::Mode::W)
                                           {
@@ -1147,8 +1146,7 @@ namespace pegasus
                                       }>(state, action_it);
 
             case 32:
-                return vfBinaryHelper<XLEN, 32, opMode,
-                                      [](auto src2, auto src1)
+                return vfBinaryHelper<XLEN, 32, opMode, [](auto src2, auto src1)
                                       {
                                           if constexpr (opMode.dst == OperandMode::Mode::W)
                                           {
@@ -1174,9 +1172,10 @@ namespace pegasus
             case 64:
                 if constexpr (opMode.dst != OperandMode::Mode::W)
                 {
-                    return vfBinaryHelper<XLEN, 64, opMode, [](auto src2, auto src1) {
-                        return Funcs::f64(float64_t{src2}, float64_t{src1}).v;
-                    }>(state, action_it);
+                    return vfBinaryHelper<XLEN, 64, opMode, [](auto src2, auto src1)
+                                          {
+                                              return Funcs::f64(float64_t{src2}, float64_t{src1}).v;
+                                          }>(state, action_it);
                 }
             default:
                 sparta_assert(false, "Unsupported SEW value");
@@ -1198,27 +1197,27 @@ namespace pegasus
                                       OperandMode{.dst = OperandMode::Mode::V,
                                                   .src2 = OperandMode::Mode::V,
                                                   .src1 = OperandMode::Mode::F},
-                                      [](auto src2, auto src1) {
-                                          return Funcs::f16(float16_t{src1}, float16_t{src2}).v;
-                                      }>(state, action_it);
+                                      [](auto src2, auto src1)
+                                      { return Funcs::f16(float16_t{src1}, float16_t{src2}).v; }>(
+                    state, action_it);
 
             case 32:
                 return vfBinaryHelper<XLEN, 32,
                                       OperandMode{.dst = OperandMode::Mode::V,
                                                   .src2 = OperandMode::Mode::V,
                                                   .src1 = OperandMode::Mode::F},
-                                      [](auto src2, auto src1) {
-                                          return Funcs::f32(float32_t{src1}, float32_t{src2}).v;
-                                      }>(state, action_it);
+                                      [](auto src2, auto src1)
+                                      { return Funcs::f32(float32_t{src1}, float32_t{src2}).v; }>(
+                    state, action_it);
 
             case 64:
                 return vfBinaryHelper<XLEN, 64,
                                       OperandMode{.dst = OperandMode::Mode::V,
                                                   .src2 = OperandMode::Mode::V,
                                                   .src1 = OperandMode::Mode::F},
-                                      [](auto src2, auto src1) {
-                                          return Funcs::f64(float64_t{src1}, float64_t{src2}).v;
-                                      }>(state, action_it);
+                                      [](auto src2, auto src1)
+                                      { return Funcs::f64(float64_t{src1}, float64_t{src2}).v; }>(
+                    state, action_it);
 
             default:
                 sparta_assert(false, "Unsupported SEW value");
@@ -1295,19 +1294,19 @@ namespace pegasus
         switch (vector_config->getSEW())
         {
             case 16:
-                return vmfBinaryHelper<XLEN, 16, opMode, [](auto src2, auto src1) {
-                    return Funcs::f16(float16_t{src2}, float16_t{src1});
-                }>(state, action_it);
+                return vmfBinaryHelper<XLEN, 16, opMode, [](auto src2, auto src1)
+                                       { return Funcs::f16(float16_t{src2}, float16_t{src1}); }>(
+                    state, action_it);
 
             case 32:
-                return vmfBinaryHelper<XLEN, 32, opMode, [](auto src2, auto src1) {
-                    return Funcs::f32(float32_t{src2}, float32_t{src1});
-                }>(state, action_it);
+                return vmfBinaryHelper<XLEN, 32, opMode, [](auto src2, auto src1)
+                                       { return Funcs::f32(float32_t{src2}, float32_t{src1}); }>(
+                    state, action_it);
 
             case 64:
-                return vmfBinaryHelper<XLEN, 64, opMode, [](auto src2, auto src1) {
-                    return Funcs::f64(float64_t{src2}, float64_t{src1});
-                }>(state, action_it);
+                return vmfBinaryHelper<XLEN, 64, opMode, [](auto src2, auto src1)
+                                       { return Funcs::f64(float64_t{src2}, float64_t{src1}); }>(
+                    state, action_it);
 
             default:
                 sparta_assert(false, "Unsupported SEW value");
@@ -1376,8 +1375,7 @@ namespace pegasus
         switch (vector_config->getSEW())
         {
             case 16:
-                return vfTernaryHelper<XLEN, 16, opMode,
-                                       [](auto src2, auto src1, auto dst)
+                return vfTernaryHelper<XLEN, 16, opMode, [](auto src2, auto src1, auto dst)
                                        {
                                            if constexpr (opMode.dst == OperandMode::Mode::W)
                                            {
@@ -1397,8 +1395,7 @@ namespace pegasus
                                        }>(state, action_it);
 
             case 32:
-                return vfTernaryHelper<XLEN, 32, opMode,
-                                       [](auto src2, auto src1, auto dst)
+                return vfTernaryHelper<XLEN, 32, opMode, [](auto src2, auto src1, auto dst)
                                        {
                                            if constexpr (opMode.dst == OperandMode::Mode::W)
                                            {
@@ -1420,10 +1417,13 @@ namespace pegasus
             case 64:
                 if constexpr (opMode.dst != OperandMode::Mode::W)
                 {
-                    return vfTernaryHelper<XLEN, 64, opMode, [](auto src2, auto src1, auto dst) {
-                        return FuncT<float64_t>{}(float64_t{src1}, float64_t{dst}, float64_t{src2})
-                            .v;
-                    }>(state, action_it);
+                    return vfTernaryHelper<XLEN, 64, opMode, [](auto src2, auto src1, auto dst)
+                                           {
+                                               return FuncT<float64_t>{}(float64_t{src1},
+                                                                         float64_t{dst},
+                                                                         float64_t{src2})
+                                                   .v;
+                                           }>(state, action_it);
                 }
             default:
                 sparta_assert(false, "Unsupported SEW value");

--- a/core/inst_handlers/v/RvvFloatInsts.cpp
+++ b/core/inst_handlers/v/RvvFloatInsts.cpp
@@ -1172,10 +1172,9 @@ namespace pegasus
             case 64:
                 if constexpr (opMode.dst != OperandMode::Mode::W)
                 {
-                    return vfBinaryHelper<XLEN, 64, opMode, [](auto src2, auto src1)
-                                          {
-                                              return Funcs::f64(float64_t{src2}, float64_t{src1}).v;
-                                          }>(state, action_it);
+                    return vfBinaryHelper<XLEN, 64, opMode, [](auto src2, auto src1) {
+                        return Funcs::f64(float64_t{src2}, float64_t{src1}).v;
+                    }>(state, action_it);
                 }
             default:
                 sparta_assert(false, "Unsupported SEW value");
@@ -1197,27 +1196,27 @@ namespace pegasus
                                       OperandMode{.dst = OperandMode::Mode::V,
                                                   .src2 = OperandMode::Mode::V,
                                                   .src1 = OperandMode::Mode::F},
-                                      [](auto src2, auto src1)
-                                      { return Funcs::f16(float16_t{src1}, float16_t{src2}).v; }>(
-                    state, action_it);
+                                      [](auto src2, auto src1) {
+                                          return Funcs::f16(float16_t{src1}, float16_t{src2}).v;
+                                      }>(state, action_it);
 
             case 32:
                 return vfBinaryHelper<XLEN, 32,
                                       OperandMode{.dst = OperandMode::Mode::V,
                                                   .src2 = OperandMode::Mode::V,
                                                   .src1 = OperandMode::Mode::F},
-                                      [](auto src2, auto src1)
-                                      { return Funcs::f32(float32_t{src1}, float32_t{src2}).v; }>(
-                    state, action_it);
+                                      [](auto src2, auto src1) {
+                                          return Funcs::f32(float32_t{src1}, float32_t{src2}).v;
+                                      }>(state, action_it);
 
             case 64:
                 return vfBinaryHelper<XLEN, 64,
                                       OperandMode{.dst = OperandMode::Mode::V,
                                                   .src2 = OperandMode::Mode::V,
                                                   .src1 = OperandMode::Mode::F},
-                                      [](auto src2, auto src1)
-                                      { return Funcs::f64(float64_t{src1}, float64_t{src2}).v; }>(
-                    state, action_it);
+                                      [](auto src2, auto src1) {
+                                          return Funcs::f64(float64_t{src1}, float64_t{src2}).v;
+                                      }>(state, action_it);
 
             default:
                 sparta_assert(false, "Unsupported SEW value");
@@ -1294,19 +1293,19 @@ namespace pegasus
         switch (vector_config->getSEW())
         {
             case 16:
-                return vmfBinaryHelper<XLEN, 16, opMode, [](auto src2, auto src1)
-                                       { return Funcs::f16(float16_t{src2}, float16_t{src1}); }>(
-                    state, action_it);
+                return vmfBinaryHelper<XLEN, 16, opMode, [](auto src2, auto src1) {
+                    return Funcs::f16(float16_t{src2}, float16_t{src1});
+                }>(state, action_it);
 
             case 32:
-                return vmfBinaryHelper<XLEN, 32, opMode, [](auto src2, auto src1)
-                                       { return Funcs::f32(float32_t{src2}, float32_t{src1}); }>(
-                    state, action_it);
+                return vmfBinaryHelper<XLEN, 32, opMode, [](auto src2, auto src1) {
+                    return Funcs::f32(float32_t{src2}, float32_t{src1});
+                }>(state, action_it);
 
             case 64:
-                return vmfBinaryHelper<XLEN, 64, opMode, [](auto src2, auto src1)
-                                       { return Funcs::f64(float64_t{src2}, float64_t{src1}); }>(
-                    state, action_it);
+                return vmfBinaryHelper<XLEN, 64, opMode, [](auto src2, auto src1) {
+                    return Funcs::f64(float64_t{src2}, float64_t{src1});
+                }>(state, action_it);
 
             default:
                 sparta_assert(false, "Unsupported SEW value");
@@ -1417,13 +1416,10 @@ namespace pegasus
             case 64:
                 if constexpr (opMode.dst != OperandMode::Mode::W)
                 {
-                    return vfTernaryHelper<XLEN, 64, opMode, [](auto src2, auto src1, auto dst)
-                                           {
-                                               return FuncT<float64_t>{}(float64_t{src1},
-                                                                         float64_t{dst},
-                                                                         float64_t{src2})
-                                                   .v;
-                                           }>(state, action_it);
+                    return vfTernaryHelper<XLEN, 64, opMode, [](auto src2, auto src1, auto dst) {
+                        return FuncT<float64_t>{}(float64_t{src1}, float64_t{dst}, float64_t{src2})
+                            .v;
+                    }>(state, action_it);
                 }
             default:
                 sparta_assert(false, "Unsupported SEW value");

--- a/core/observers/STFLogger.cpp
+++ b/core/observers/STFLogger.cpp
@@ -42,7 +42,7 @@ namespace pegasus
         // TODO: Add support for PTE
         // stf_writer_.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_PTE);
 
-        const auto & isa = state->getCore()->getISAString();
+        const auto & isa = state->getISAString();
 
         stf_writer_.setVLen(state->getVectorConfig()->getVLEN());
         stf_writer_.setISA(stf::ISA::RISCV);

--- a/cosim/CoSimEventPipeline.cpp
+++ b/cosim/CoSimEventPipeline.cpp
@@ -589,7 +589,9 @@ namespace pegasus::cosim
             checkpointer->getFastCheckpointer().loadCheckpoint(euid);
 
             last_event_uid_ = euid;
+
             sim_stopped_ = reload_evt.isLastEvent();
+            state->setSimStopped(sim_stopped_, reload_evt.getWorkloadExitCode());
 
             state->setPc(reload_evt.getNextPc());
             state->setPrivMode(reload_evt.getNextPrivilegeMode(), state->getVirtualMode());
@@ -612,13 +614,7 @@ namespace pegasus::cosim
             sim_state->reset();
             sim_state->current_opcode = reload_evt.getOpcode();
             sim_state->current_uid = reload_evt.getSimStateCurrentUID();
-            sim_state->sim_stopped = reload_evt.isLastEvent();
             sim_state->inst_count = reload_evt.getSimStateCurrentUID();
-            sim_state->test_passed = sim_state->workload_exit_code == 0;
-            if (!sim_state->sim_stopped)
-            {
-                sim_state->workload_exit_code = 0;
-            }
 
             // Now that the ArchData is reloaded, we can safely update the MMU mode.
             if (change_mmu_mode)

--- a/cosim/PegasusCoSim.cpp
+++ b/cosim/PegasusCoSim.cpp
@@ -55,8 +55,8 @@ namespace pegasus::cosim
     }
 
     PegasusCoSim::PegasusCoSim(uint64_t ilimit, const std::string & workload,
-                               const std::map<std::string, std::string> pegasus_params,
-                               const std::vector<std::vector<std::string>> pegasus_loggers,
+                               const std::map<std::string, std::string> & pegasus_params,
+                               const std::vector<std::vector<std::string>> & pegasus_loggers,
                                const std::string & db_file, const size_t snapshot_threshold)
     {
         sim_config_.reset(new sparta::app::SimulationConfiguration);

--- a/cosim/PegasusCoSim.cpp
+++ b/cosim/PegasusCoSim.cpp
@@ -56,6 +56,7 @@ namespace pegasus::cosim
 
     PegasusCoSim::PegasusCoSim(uint64_t ilimit, const std::string & workload,
                                const std::map<std::string, std::string> pegasus_params,
+                               const std::vector<std::vector<std::string>> pegasus_loggers,
                                const std::string & db_file, const size_t snapshot_threshold)
     {
         sim_config_.reset(new sparta::app::SimulationConfiguration);
@@ -64,6 +65,11 @@ namespace pegasus::cosim
         {
             constexpr bool OPTIONAL = false;
             sim_config_->processParameter(param, value, OPTIONAL);
+        }
+
+        for (auto & logger_param : pegasus_loggers)
+        {
+            sim_config_->enableLogging(logger_param.at(0), logger_param.at(1), logger_param.at(2));
         }
 
         // Instruction count limit

--- a/cosim/PegasusCoSim.hpp
+++ b/cosim/PegasusCoSim.hpp
@@ -75,6 +75,7 @@ namespace pegasus::cosim
       public:
         PegasusCoSim(uint64_t ilimit = 0, const std::string & workload = "",
                      const std::map<std::string, std::string> pegasus_params = {},
+                     const std::vector<std::vector<std::string>> pegasus_loggers = {},
                      const std::string & db_file = "pegasus-cosim.db",
                      const size_t snapshot_threshold = 100);
 

--- a/cosim/PegasusCoSim.hpp
+++ b/cosim/PegasusCoSim.hpp
@@ -74,8 +74,8 @@ namespace pegasus::cosim
     {
       public:
         PegasusCoSim(uint64_t ilimit = 0, const std::string & workload = "",
-                     const std::map<std::string, std::string> pegasus_params = {},
-                     const std::vector<std::vector<std::string>> pegasus_loggers = {},
+                     const std::map<std::string, std::string> & pegasus_params = {},
+                     const std::vector<std::vector<std::string>> & pegasus_loggers = {},
                      const std::string & db_file = "pegasus-cosim.db",
                      const size_t snapshot_threshold = 100);
 

--- a/scripts/RunArchTests.py
+++ b/scripts/RunArchTests.py
@@ -71,8 +71,6 @@ def get_pegasus_cmd(testname, wkld, output_dir, executable):
     if be_noisy:
         print("Running", testname)
     rv32_test = "rv32" in testname
-    logname = output_dir + testname + ".log"
-    instlogname = output_dir + testname + ".instlog"
     error_dump = output_dir + testname + ".error"
     isa_string = "gcbvh_zicsr_zifencei_zicond_zfh_zbkb_zbkx_zicboz_zicntr"
     isa_string = "rv32"+isa_string if rv32_test else "rv64"+isa_string
@@ -96,12 +94,10 @@ def run_test(testname, pegasus_cmd, output_dir, passing_tests, failing_tests, ti
         timeout_tests.append(testname)
 
     if test_passed:
-        # Remove log files if test passed
-        if os.path.exists(logname):
-            os.remove(logname)
-        # Warn if test passed but log is missing (does not apply to CoSim harness)
-        elif pegasus_cmd[0].find('FlushWorkload_test') == -1:
-            print("WARNING: Test passed but Pegasus log is missing:", logname)
+        pattern = re.compile(rf"\b{testname}\b.*\.log$")
+        for filename in os.listdir(output_dir):
+            if re.search(pattern, filename):
+                os.remove(filename)
         passing_tests.append(testname)
     else:
         error = 'UNKNOWN'

--- a/scripts/RunArchTests.py
+++ b/scripts/RunArchTests.py
@@ -74,7 +74,7 @@ def get_pegasus_cmd(testname, wkld, output_dir, executable):
     logname = output_dir + testname + ".log"
     instlogname = output_dir + testname + ".instlog"
     error_dump = output_dir + testname + ".error"
-    isa_string = "gcbvh_zicsr_zifencei_zicond_zfh_zbkb_zbkx_zicboz"
+    isa_string = "gcbvh_zicsr_zifencei_zicond_zfh_zbkb_zbkx_zicboz_zicntr"
     isa_string = "rv32"+isa_string if rv32_test else "rv64"+isa_string
     pegasus_cmd = [executable,
                  "--debug-dump-filename", error_dump,

--- a/system/PegasusSystem.cpp
+++ b/system/PegasusSystem.cpp
@@ -351,8 +351,8 @@ namespace pegasus
             if (data != nullptr)
             {
                 std::cout << "  -- Loading section " << segment_name << " (" << std::dec
-                          << segment->get_file_size() << "B) "
-                          << " to 0x" << std::hex << segment->get_memory_size() << std::endl;
+                          << segment->get_file_size() << "B) " << " to 0x" << std::hex
+                          << segment->get_memory_size() << std::endl;
 
                 bool success = memory_map_->tryPoke(segment->get_physical_address(),
                                                     segment->get_file_size(), data);

--- a/system/SystemCallEmulator.cpp
+++ b/system/SystemCallEmulator.cpp
@@ -629,8 +629,7 @@ namespace pegasus
         auto ret = ::unlinkat(dirfd, pathname_str.c_str(), flags);
 
         SYSCALL_LOG(__func__ << "(" << dirfd << "," << HEX16(pathname_addr) << "['" << pathname_str
-                             << "']"
-                             << "-> " << ret);
+                             << "']" << "-> " << ret);
         return ret;
     }
 

--- a/test/actions/TestComponents.hpp
+++ b/test/actions/TestComponents.hpp
@@ -144,9 +144,8 @@ class ExecuteUnit : public Unit
                                           pegasus::Action::ItrType action_it)
     {
         const pegasus::PegasusInstPtr & inst = state->getCurrentInst();
-        std::cout << "Executing "
-                  << "uid: " << std::dec << inst->getUid() << " " << inst->dasmString()
-                  << std::endl;
+        std::cout << "Executing " << "uid: " << std::dec << inst->getUid() << " "
+                  << inst->dasmString() << std::endl;
         state->getSimState()->inst_count++;
 
         // Determine if the inst handler needs to be called again

--- a/test/cosim/cosim_workload/flush_workload/FlushWorkload_test.cpp
+++ b/test/cosim/cosim_workload/flush_workload/FlushWorkload_test.cpp
@@ -441,7 +441,8 @@ int main(int argc, char** argv)
 
     const size_t snapshot_threshold = 10;
 
-    auto initSimConfig = [&](const std::string log_suffix) -> sparta::app::SimulationConfiguration*
+    auto initSimConfig =
+        [&](const std::string & log_suffix) -> sparta::app::SimulationConfiguration*
     {
         static std::unique_ptr<sparta::app::SimulationConfiguration> config_truth;
         config_truth.reset(new sparta::app::SimulationConfiguration);
@@ -452,7 +453,7 @@ int main(int argc, char** argv)
         }
 
         config_truth->enableLogging("top", "inst", workload_fname + "." + log_suffix + ".log");
-        file_cleanup.cleanupOnSuccess(workload_fname + ".log");
+        file_cleanup.cleanupOnSuccess(workload_fname + "." + log_suffix + ".log");
         pegasus::PegasusSimParameters::WorkloadsAndArgs workloads_and_args{{workload}};
         const std::string wkld_param =
             pegasus::PegasusSimParameters::convertVectorToStringParam(workloads_and_args);
@@ -466,7 +467,7 @@ int main(int argc, char** argv)
     sparta::Scheduler scheduler_truth;
     PegasusSim cosim_truth(&scheduler_truth);
 
-    cosim_truth.configure(0, nullptr, initSimConfig("truth"));
+    cosim_truth.configure(0, nullptr, initSimConfig("cosim_truth"));
     cosim_truth.buildTree();
     cosim_truth.configureTree();
     cosim_truth.finalizeTree();
@@ -587,7 +588,7 @@ int main(int argc, char** argv)
         sparta::Scheduler replayer_scheduler_truth;
         PegasusSim replayer_truth(&replayer_scheduler_truth);
 
-        replayer_truth.configure(0, nullptr, initSimConfig("replayer"));
+        replayer_truth.configure(0, nullptr, initSimConfig("replayer_truth"));
         replayer_truth.buildTree();
         replayer_truth.configureTree();
         replayer_truth.finalizeTree();

--- a/test/cosim/cosim_workload/flush_workload/FlushWorkload_test.cpp
+++ b/test/cosim/cosim_workload/flush_workload/FlushWorkload_test.cpp
@@ -441,7 +441,7 @@ int main(int argc, char** argv)
 
     const size_t snapshot_threshold = 10;
 
-    auto initSimConfig = [&]() -> sparta::app::SimulationConfiguration*
+    auto initSimConfig = [&](const std::string log_suffix) -> sparta::app::SimulationConfiguration*
     {
         static std::unique_ptr<sparta::app::SimulationConfiguration> config_truth;
         config_truth.reset(new sparta::app::SimulationConfiguration);
@@ -451,7 +451,7 @@ int main(int argc, char** argv)
             config_truth->processParameter(param_name, param_value, false);
         }
 
-        config_truth->enableLogging("top", "inst", workload_fname + ".log");
+        config_truth->enableLogging("top", "inst", workload_fname + "." + log_suffix + ".log");
         file_cleanup.cleanupOnSuccess(workload_fname + ".log");
         pegasus::PegasusSimParameters::WorkloadsAndArgs workloads_and_args{{workload}};
         const std::string wkld_param =
@@ -466,7 +466,7 @@ int main(int argc, char** argv)
     sparta::Scheduler scheduler_truth;
     PegasusSim cosim_truth(&scheduler_truth);
 
-    cosim_truth.configure(0, nullptr, initSimConfig());
+    cosim_truth.configure(0, nullptr, initSimConfig("truth"));
     cosim_truth.buildTree();
     cosim_truth.configureTree();
     cosim_truth.finalizeTree();
@@ -484,7 +484,12 @@ int main(int argc, char** argv)
         }
     }
 
-    PegasusCoSim cosim_test(ilimit, workload, sim_params, db_test, snapshot_threshold);
+    // Enable logging
+    const std::vector<std::vector<std::string>> loggers = {
+        {"top", "inst", workload_fname + ".cosim.log"},
+        {"top", "cosim", workload_fname + ".cosim.log"},
+    };
+    PegasusCoSim cosim_test(ilimit, workload, sim_params, loggers, db_test, snapshot_threshold);
 
     const pegasus::CoreId core_id = 0;
     const pegasus::HartId hart_id = 0;
@@ -582,7 +587,7 @@ int main(int argc, char** argv)
         sparta::Scheduler replayer_scheduler_truth;
         PegasusSim replayer_truth(&replayer_scheduler_truth);
 
-        replayer_truth.configure(0, nullptr, initSimConfig());
+        replayer_truth.configure(0, nullptr, initSimConfig("replayer"));
         replayer_truth.buildTree();
         replayer_truth.configureTree();
         replayer_truth.finalizeTree();


### PR DESCRIPTION
Removed extra ExtensionManager left in PegasusCore after a recent PR, which required moving a lot of other PegasusCore methods into PegasusState. Also added new parameters to set an HART's ISA string and privilege mode when it boots.