### PR TITLE
Added Support for Zvfh and Zvfhmin

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ set(PEGASUS_DISABLE_STANDALONE True)
 | **Zfhmin** Half-precision floating-point. | :white_check_mark: |
 | **Zkt** Data-independent execution latency. | :x: |
 | **V** Vector extension. | :white_check_mark: |
-| **Zvfhmin** Vector minimal half-precision floating-point. | :x: |
+| **Zvfhmin** Vector minimal half-precision floating-point. | :white_check_mark: |
 | **Zvbb** Vector basic bit-manipulation instructions. | :white_check_mark: |
 | **Zvkt** Vector data-independent execution latency. | :x: |
 | **Zihintntl** Non-temporal locality hints. | :white_check_mark: |
@@ -255,7 +255,7 @@ set(PEGASUS_DISABLE_STANDALONE True)
 | **Zbc** Scalar carryless multiply. | :white_check_mark: |
 | **Zicfilp** Landing Pads. | :x: |
 | **Zicfiss** Shadow Stack. | :x: |
-| **Zvfh** Vector half-precision floating-point. | :x: |
+| **Zvfh** Vector half-precision floating-point. | :white_check_mark: |
 | **Zfbfmin** Scalar BF16 converts. | :x: |
 | **Zvfbfmin** Vector BF16 converts. | :x: |
 | **Zvfbfwma** Vector BF16 widening mul-add. | :x: |

--- a/core/Fetch.cpp
+++ b/core/Fetch.cpp
@@ -167,6 +167,20 @@ namespace pegasus
             state->getFetchTranslationState()->popRequest();
         }
 
+        // Check if Zvfh/Zvfhmin are enabled for vector BF16 support
+        if (SPARTA_EXPECT_FALSE(inst->isVector() && inst->isFloat()
+                                && (state->getVectorConfig()->getSEW() == 16)))
+        {
+            if (false == state->isExtensionEnabled("zfh"))
+            {
+                if (false == (state->isExtensionEnabled("zfhmin") && inst->hasMavisTag("zfhmin")))
+                {
+                    THROW_ILLEGAL_INST;
+                }
+            }
+        }
+
+        // FIXME: This is probably not the best place for these checks
         if (SPARTA_EXPECT_FALSE(inst->hasCsr()))
         {
             const uint32_t csr =
@@ -176,7 +190,6 @@ namespace pegasus
                 THROW_ILLEGAL_INST;
             }
 
-            // TODO: This is probably not the best place for this check...
             if (csr == SATP)
             {
                 const uint32_t tvm_val = READ_CSR_FIELD<RV64>(state, MSTATUS, "tvm");

--- a/core/PegasusInst.hpp
+++ b/core/PegasusInst.hpp
@@ -51,6 +51,16 @@ namespace pegasus
 
         uint64_t getImmediate() const { return immediate_value_; }
 
+        bool isVector() const
+        {
+            return opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::VECTOR);
+        }
+
+        bool isFloat() const
+        {
+            return opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::FLOAT);
+        }
+
         bool hasCsr() const
         {
             return opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::CSR);
@@ -60,6 +70,11 @@ namespace pegasus
         {
             sparta_assert(hasCsr(), "Failed to get CSR!");
             return opcode_info_->getSpecialField(mavis::OpcodeInfo::SpecialField::CSR);
+        }
+
+        bool hasMavisTag(const std::string & tag) const
+        {
+            return opcode_info_->getTags().isMember(tag);
         }
 
         bool unimplemented() const { return extractor_info_->isUnimplemented(); }

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -187,6 +187,13 @@ namespace pegasus
 
         // Update VectorConfig vlen
         vector_config_.setVLEN(vlen_);
+        vector_config_.setLMUL(p->init_lmul);
+        vector_config_.setSEW(p->init_sew);
+        vector_config_.setVTA(p->init_vta);
+        vector_config_.setVMA(p->init_vma);
+        vector_config_.setVL(p->init_vl);
+        vector_config_.setVSTART(p->init_vstart);
+        vector_config_.checkConfig();
     }
 
     mavis::FileNameListType PegasusState::getUArchFiles_() const

--- a/core/PegasusState.hpp
+++ b/core/PegasusState.hpp
@@ -69,6 +69,13 @@ namespace pegasus
             PARAMETER(uint32_t, hart_id, UINT32_MAX, "Hart ID")
             PARAMETER(char, priv_mode, 'm', "Privilege mode at boot (m, s, or u)")
             PARAMETER(uint32_t, vlen, 256, "Vector register size in bits (max: 1024)")
+            PARAMETER(uint32_t, init_lmul, 8,
+                      "Initial vector LMUL in units of 1/8 (e.g. 8=1, 16=2, 4=1/2)")
+            PARAMETER(uint32_t, init_sew, 8, "Initial vector SEW in bits")
+            PARAMETER(bool, init_vta, false, "Initial vector tail agnostic state")
+            PARAMETER(bool, init_vma, false, "Initial vector mask agnostic state")
+            PARAMETER(uint32_t, init_vl, 0, "Initial vector length (VL)")
+            PARAMETER(uint32_t, init_vstart, 0, "Initial vector start index (VSTART)")
             PARAMETER(uint32_t, ilimit, 0, "Instruction limit for stopping simulation")
             PARAMETER(uint32_t, quantum, 500, "Instruction quantum size")
             PARAMETER(bool, stop_sim_on_wfi, false, "Executing a WFI instruction stops simulation")

--- a/scripts/insts/RVV_INST.py
+++ b/scripts/insts/RVV_INST.py
@@ -1,4 +1,4 @@
-RVV_MAVIS_EXTS = ["v", "zve32x", "zve32f", "zve64f", "zve64d", "zve64x"]
+RVV_MAVIS_EXTS = ["v", "zve32x", "zve32f", "zve64f", "zve64d", "zve64x", "zvfh", "zvfhmin"]
 
 RV32ZVE32X_INST = [
     {'mnemonic': 'vsetvli', 'handler': 'vsetvli', 'cost': 1, 'tags': 'V_EXT_32', 'memory': False, 'cof': False},


### PR DESCRIPTION
The Zvfh/Zvfhmin extensions enable BF16 for the vector floating point instructions. There are no "new" instructions; Pegasus just needs to check whether the required extension is enabled before executing any vector floating point instructions when SEW=16.

Also added parameters to set the initial vector config, which is needed for testing single vector instructions.