### PR TITLE
STF Logger Opcode calculation fix

### DIFF
--- a/core/observers/STFLogger.cpp
+++ b/core/observers/STFLogger.cpp
@@ -391,6 +391,15 @@ namespace pegasus
         else
         {
             opcode = state->getSimState()->current_opcode;
+            uint32_t last_two_bits = opcode & 0b11;
+            if (last_two_bits == 0b11)
+            {
+                opcode_size = 4;
+            }
+            else
+            {
+                opcode_size = 2;
+            }
         }
 
         if (opcode_size == 2)


### PR DESCRIPTION
Trace file gets corrupted because `core/observers/STFLogger.cpp` writes all the instructions as non compressed hence, compressed instruction cause error when trying to read them due to byte miss alignment. 

Here is the original error while reading the trace file generated through pegasus : 

```bash
jha@MAGICIAN:~/workspace/opensource/olympia/release$ ./olympia dhrystone.zstf
# Name:     Olympia RISC-V Perf Model
# Cmdline:  ./olympia dhrystone.zstf
# Exe:      ./olympia
# SimulatorVersion: v0.1.0
# Repro:    Git SHA: 8389bb4
# Start:    Wednesday Wed May 13 16:10:47 2026
# Elapsed:  0.001164s
# Sparta Version: map_v2.1.0-47-g1a72f8b3
  [in] Arch Config: ArchCfg Node "" <- file: "/home/jha/workspace/opensource/olympia/arches/small_core.yaml"

Setting up Simulation Content...
Resources:
  cpu
Building tree...
Configuring tree...
Finalizing tree...
Inst Allocator: 1238 Inst objects allocated/created
Inst Allocator: 1238 Inst objects allocated/created
Inst Allocator: 0 Inst objects allocated/created
Inst Allocator: 0 Inst objects allocated/created
Inst Allocator: 1238 Inst objects allocated/created
Preparing to run...
Meta-Parameters:
  architecture: small_core
  is_final_config: false
Non-default model parameters: 8
Running...
olympia: STF file input detected
ERROR: Mavis failed decoding: 0x0 for STF It PC: 0x2 STFID: 35 err: Opcode 0x0 is illegal for instruction 'c.addi4spn'
Exception while running
Opcode 0x0 is illegal for instruction 'c.addi4spn'
  [out] Writing error dump file 'error-dump.dbg'
  [out] Debug state written to "error-dump.dbg"
Fetch Buffer Contents
        uid:19    FETCHED 80000024 pid:19 uopid:0 'c.li x19, x0, +0x0'
        uid:20    FETCHED 80000026 pid:20 uopid:0 'c.li x20, x0, +0x0'
        uid:21    FETCHED 80000028 pid:21 uopid:0 'c.li x21, x0, +0x0'
        uid:22    FETCHED 8000002a pid:22 uopid:0 'c.li x22, x0, +0x0'
        uid:23    FETCHED 8000002c pid:23 uopid:0 'c.li x23, x0, +0x0'
        uid:24    FETCHED 8000002e pid:24 uopid:0 'c.li x24, x0, +0x0'
        uid:25 BEFORE_FETCH 80000030 pid:25 uopid:0 'c.li       x25, x0, +0x0'
        uid:26 BEFORE_FETCH 80000032 pid:26 uopid:0 'c.li       x26, x0, +0x0'
        uid:27 BEFORE_FETCH 80000034 pid:27 uopid:0 'c.li       x27, x0, +0x0'
        uid:28 BEFORE_FETCH 80000036 pid:28 uopid:0 'c.li       x28, x0, +0x0'
        uid:29 BEFORE_FETCH 80000038 pid:29 uopid:0 'c.li       x29, x0, +0x0'
        uid:30 BEFORE_FETCH 8000003a pid:30 uopid:0 'c.li       x30, x0, +0x0'
        uid:31 BEFORE_FETCH 8000003c pid:31 uopid:0 'c.li       x31, x0, +0x0'
        uid:32 BEFORE_FETCH 8000003e pid:32 uopid:0 'c.lui      x5, +0x1e000'
Warning: suppressed exception in onStartingTeardown_ at top.cpu.core0.fetch:
false: fetch buffer has pending instructions: in file: '/home/jha/workspace/opensource/olympia/core/fetch/Fetch.cpp', on line: 322
WARNING! Simulation is ending, but the ROB didn't stop it.  Lock up situation?
ROB Contents
        uid:3  COMPLETED 80000004 pid:3 uopid:0 'c.li   x3, x0, +0x0'
        uid:4  SCHEDULED 80000006 pid:4 uopid:0 'c.li   x4, x0, +0x0'
        uid:5  SCHEDULED 80000008 pid:5 uopid:0 'c.li   x5, x0, +0x0'
Inst Allocator: 1238 Inst objects allocated/created
Inst Allocator: 1238 Inst objects allocated/created
Inst Allocator: 67 Inst objects allocated/created
terminate called after throwing an instance of 'mavis::IllegalOpcode'
  what():  Opcode 0x0 is illegal for instruction 'c.addi4spn'
Aborted (core dumped)
```

As seen in the error - all it is the compressed type instructions that are causing this error.

A new trace file that was generated using the same binary and pegasus runs successfully now. 

```bash
jha@MAGICIAN:~/workspace/opensource/olympia/release$ ./olympia /home/jha/workspace/opensource/pegasus/build/sim/trace.zstf
# Name:     Olympia RISC-V Perf Model
# Cmdline:  ./olympia /home/jha/workspace/opensource/pegasus/build/sim/trace.zstf
# Exe:      ./olympia
# SimulatorVersion: v0.1.0
# Repro:    Git SHA: 8389bb4
# Start:    Wednesday Wed May 13 16:10:28 2026
# Elapsed:  0.001198s
# Sparta Version: map_v2.1.0-47-g1a72f8b3
  [in] Arch Config: ArchCfg Node "" <- file: "/home/jha/workspace/opensource/olympia/arches/small_core.yaml"

Setting up Simulation Content...
Resources:
  cpu
Building tree...
Configuring tree...
Finalizing tree...
Inst Allocator: 1238 Inst objects allocated/created
Inst Allocator: 1238 Inst objects allocated/created
Inst Allocator: 0 Inst objects allocated/created
Inst Allocator: 0 Inst objects allocated/created
Inst Allocator: 1238 Inst objects allocated/created
Preparing to run...
Meta-Parameters:
  architecture: small_core
  is_final_config: false
Non-default model parameters: 8
Running...
olympia: STF file input detected
Running Complete
  Simulation Performance      : wall(0.0900), system(0.0000), user(0.0800)
  Scheduler Tick Rate  (KTPS): 16.8625  (1k ticks per second)
  Scheduler Event Rate (KEPS): 275.613 KEPS (1k events per second)
  Scheduler Events Fired: 22049
Run Successful!
Saving reports...
Inst Allocator: 1238 Inst objects allocated/created
Inst Allocator: 1238 Inst objects allocated/created
Inst Allocator: 490 Inst objects allocated/created
```

Please look into it, if it is the correct fix : @bdutro 

Thanks