### PR TITLE
adding docstring and example for VectorConfig and VecElements

### DIFF
--- a/core/VecElements.hpp
+++ b/core/VecElements.hpp
@@ -303,7 +303,22 @@ namespace pegasus
      * performed.
      * Element iterator is provided for element iteration; bit iterator for
      * vector mask regitster bit iteration.
-     *
+     */
+
+    // clang-format off
+    /**
+     * Here is an example of using ElementIterator to set *Element* value for vector register group
+     * vs2 *Elements* with SEW=16:
+     * Elements<Element<16>, false> elems{state, inst->getVectorConfig(), inst->getRs2()};
+     * for (auto iter = elems_vd.begin(); iter != elems_vd.end(); ++iter)
+     * {
+     *     auto index = iter.getIndex();
+     *     elems.getElement(index).setVal(elems.getElement(index).getVal());
+     * }
+     */
+    // clang-format on
+
+    /**
      * @tparam EType       Element type for individual element.
      * @tparam isMaskElems True if this *Elements* represents vector mask.
      */

--- a/core/VectorConfig.cpp
+++ b/core/VectorConfig.cpp
@@ -4,6 +4,19 @@
 
 namespace pegasus
 {
+    /**
+     * @brief Compares the current VectorConfig object with another VectorConfig object.
+     *
+     * This function compares the fields of the current VectorConfig object with those of
+     * another VectorConfig object. If `IS_UNIT_TEST` is `true`, the comparison uses unit
+     * test assertions to validate equality. Otherwise, it performs a field-by-field
+     * comparison and returns `true` if all fields are equal, or `false` otherwise.
+     *
+     * @tparam IS_UNIT_TEST A boolean indicating whether the function is being used in a unit test
+     * context. If `true`, unit test assertions are used for comparison.
+     * @param config Pointer to the VectorConfig object to compare against.
+     * @return `true` if all fields are equal (when `IS_UNIT_TEST` is `false`), otherwise `false`.
+     */
     template <bool IS_UNIT_TEST> bool VectorConfig::compare(const VectorConfig* config) const
     {
         if constexpr (IS_UNIT_TEST)

--- a/core/VectorConfig.hpp
+++ b/core/VectorConfig.hpp
@@ -11,6 +11,18 @@ namespace pegasus
 
     class PegasusState;
 
+    /**
+     * @brief Represents the configuration of a RISC-V vector unit.
+     *
+     * The `VectorConfig` class encapsulates the configuration parameters of a RISC-V vector unit,
+     * including vector length (VLEN), vector length multiplier (LMUL), standard element width
+     * (SEW), tail agnostic mode (VTA), mask agnostic mode (VMA), vector length (VL), and vector
+     * start index (VSTART). It provides member accessors and mutators for these parameters,
+     * ensuring that constraints such as VLEN being a power of 2 and greater than or equal to
+     * `VLEN_MIN` are enforced.
+     *
+     * @note This class is used to manage and validate the state of the vector unit configuration.
+     */
     class VectorConfig
     {
       public:


### PR DESCRIPTION
I have added more docs for Vector Elements related, including an example to iterate Elements, which is the core functionality in vector and matmul.
I also reviewed existing doc in `VectorElements.hpp`, it seems pretty completed.