### PR TITLE
Vector divide protections

### DIFF
--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -318,9 +318,9 @@ namespace pegasus
         {
             if (false == pegasus_core_->isExtensionSupported(xlen_, ext.first))
             {
-                sparta_assert(false, "ISA extension: " << ext.first
-                                                       << " is not supported in Pegasus: "
-                                                       << isa_string_);
+                sparta_assert(false,
+                              "ISA extension: " << ext.first
+                                                << " is not supported in Pegasus: " << isa_string_);
             }
         }
 

--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -319,7 +319,7 @@ namespace pegasus
             if (false == pegasus_core_->isExtensionSupported(xlen_, ext.first))
             {
                 sparta_assert(false, "ISA extension: " << ext.first
-                                                       << " is not supported in isa_string: "
+                                                       << " is not supported in Pegasus: "
                                                        << isa_string_);
             }
         }

--- a/core/inst_handlers/v/RvvIntegerInsts.cpp
+++ b/core/inst_handlers/v/RvvIntegerInsts.cpp
@@ -9,6 +9,25 @@
 
 namespace pegasus
 {
+    template <template<typename> typename FuncT>
+    struct DivByZeroProtect
+    {
+        template <typename T = void>
+        struct DivisorChecker
+        {
+            FuncT<T> operation;
+            // Check the divisor.  On ARM-based systems, integer
+            // divide does not except. On x86, it does.  RISC-V does
+            // not except.
+            constexpr T operator()(T&& in_x, T&& in_y) const {
+                if (in_y != 0) {
+                    return operation(std::forward<T>(in_x), std::forward<T>(in_y));
+                }
+                return T(0);
+            }
+        };
+    };
+
     template <typename XLEN>
     void RvvIntegerInsts::getInstHandlers(std::map<std::string, Action> & inst_handlers)
     {
@@ -996,7 +1015,7 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::V},
-                                                   false, std::divides>,
+                                                   false, DivByZeroProtect<std::divides>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vdivu.vv", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vdivu.vx",
@@ -1005,7 +1024,7 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::X},
-                                                   false, std::divides>,
+                                                   false, DivByZeroProtect<std::divides>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vdivu.vx", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vdiv.vv",
@@ -1014,7 +1033,7 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::V},
-                                                   true, std::divides>,
+                                                   true, DivByZeroProtect<std::divides>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vdiv.vv", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vdiv.vx",
@@ -1023,8 +1042,9 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::X},
-                                                   true, std::divides>,
+                                                   true, DivByZeroProtect<std::divides>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vdiv.vx", ActionTags::EXECUTE_TAG));
+
         inst_handlers.emplace(
             "vremu.vv",
             pegasus::Action::createAction<
@@ -1032,7 +1052,7 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::V},
-                                                   false, std::modulus>,
+                                                  false, DivByZeroProtect<std::modulus>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vremu.vv", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vremu.vx",
@@ -1041,7 +1061,7 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::X},
-                                                   false, std::modulus>,
+                                                   false, DivByZeroProtect<std::modulus>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vremu.vx", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vrem.vv",
@@ -1050,7 +1070,7 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::V},
-                                                   true, std::modulus>,
+                                                   true, DivByZeroProtect<std::modulus>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vrem.vv", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vrem.vx",
@@ -1059,7 +1079,7 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::X},
-                                                   true, std::modulus>,
+                                                   true, DivByZeroProtect<std::modulus>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vrem.vx", ActionTags::EXECUTE_TAG));
 
         inst_handlers.emplace(

--- a/core/inst_handlers/v/RvvIntegerInsts.cpp
+++ b/core/inst_handlers/v/RvvIntegerInsts.cpp
@@ -9,18 +9,19 @@
 
 namespace pegasus
 {
-    template <template<typename> typename FuncT>
-    struct DivByZeroProtect
+    template <template <typename> typename FuncT> struct DivByZeroProtect
     {
-        template <typename T = void>
-        struct DivisorChecker
+        template <typename T = void> struct DivisorChecker
         {
             FuncT<T> operation;
+
             // Check the divisor.  On ARM-based systems, integer
             // divide does not except. On x86, it does.  RISC-V does
             // not except.
-            constexpr T operator()(T&& in_x, T&& in_y) const {
-                if (in_y != 0) {
+            constexpr T operator()(T && in_x, T && in_y) const
+            {
+                if (in_y != 0)
+                {
                     return operation(std::forward<T>(in_x), std::forward<T>(in_y));
                 }
                 return T(0);
@@ -1015,7 +1016,8 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::V},
-                                                   false, DivByZeroProtect<std::divides>::DivisorChecker>,
+                                                   false,
+                                                   DivByZeroProtect<std::divides>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vdivu.vv", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vdivu.vx",
@@ -1024,26 +1026,29 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::X},
-                                                   false, DivByZeroProtect<std::divides>::DivisorChecker>,
+                                                   false,
+                                                   DivByZeroProtect<std::divides>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vdivu.vx", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vdiv.vv",
-            pegasus::Action::createAction<
-                &RvvIntegerInsts::viBinaryHandler_<XLEN,
-                                                   OperandMode{.dst = OperandMode::Mode::V,
-                                                               .src2 = OperandMode::Mode::V,
-                                                               .src1 = OperandMode::Mode::V},
-                                                   true, DivByZeroProtect<std::divides>::DivisorChecker>,
-                RvvIntegerInsts>(nullptr, "vdiv.vv", ActionTags::EXECUTE_TAG));
+            pegasus::Action::createAction<&RvvIntegerInsts::viBinaryHandler_<
+                                              XLEN,
+                                              OperandMode{.dst = OperandMode::Mode::V,
+                                                          .src2 = OperandMode::Mode::V,
+                                                          .src1 = OperandMode::Mode::V},
+                                              true, DivByZeroProtect<std::divides>::DivisorChecker>,
+                                          RvvIntegerInsts>(nullptr, "vdiv.vv",
+                                                           ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vdiv.vx",
-            pegasus::Action::createAction<
-                &RvvIntegerInsts::viBinaryHandler_<XLEN,
-                                                   OperandMode{.dst = OperandMode::Mode::V,
-                                                               .src2 = OperandMode::Mode::V,
-                                                               .src1 = OperandMode::Mode::X},
-                                                   true, DivByZeroProtect<std::divides>::DivisorChecker>,
-                RvvIntegerInsts>(nullptr, "vdiv.vx", ActionTags::EXECUTE_TAG));
+            pegasus::Action::createAction<&RvvIntegerInsts::viBinaryHandler_<
+                                              XLEN,
+                                              OperandMode{.dst = OperandMode::Mode::V,
+                                                          .src2 = OperandMode::Mode::V,
+                                                          .src1 = OperandMode::Mode::X},
+                                              true, DivByZeroProtect<std::divides>::DivisorChecker>,
+                                          RvvIntegerInsts>(nullptr, "vdiv.vx",
+                                                           ActionTags::EXECUTE_TAG));
 
         inst_handlers.emplace(
             "vremu.vv",
@@ -1052,7 +1057,8 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::V},
-                                                  false, DivByZeroProtect<std::modulus>::DivisorChecker>,
+                                                   false,
+                                                   DivByZeroProtect<std::modulus>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vremu.vv", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vremu.vx",
@@ -1061,26 +1067,29 @@ namespace pegasus
                                                    OperandMode{.dst = OperandMode::Mode::V,
                                                                .src2 = OperandMode::Mode::V,
                                                                .src1 = OperandMode::Mode::X},
-                                                   false, DivByZeroProtect<std::modulus>::DivisorChecker>,
+                                                   false,
+                                                   DivByZeroProtect<std::modulus>::DivisorChecker>,
                 RvvIntegerInsts>(nullptr, "vremu.vx", ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vrem.vv",
-            pegasus::Action::createAction<
-                &RvvIntegerInsts::viBinaryHandler_<XLEN,
-                                                   OperandMode{.dst = OperandMode::Mode::V,
-                                                               .src2 = OperandMode::Mode::V,
-                                                               .src1 = OperandMode::Mode::V},
-                                                   true, DivByZeroProtect<std::modulus>::DivisorChecker>,
-                RvvIntegerInsts>(nullptr, "vrem.vv", ActionTags::EXECUTE_TAG));
+            pegasus::Action::createAction<&RvvIntegerInsts::viBinaryHandler_<
+                                              XLEN,
+                                              OperandMode{.dst = OperandMode::Mode::V,
+                                                          .src2 = OperandMode::Mode::V,
+                                                          .src1 = OperandMode::Mode::V},
+                                              true, DivByZeroProtect<std::modulus>::DivisorChecker>,
+                                          RvvIntegerInsts>(nullptr, "vrem.vv",
+                                                           ActionTags::EXECUTE_TAG));
         inst_handlers.emplace(
             "vrem.vx",
-            pegasus::Action::createAction<
-                &RvvIntegerInsts::viBinaryHandler_<XLEN,
-                                                   OperandMode{.dst = OperandMode::Mode::V,
-                                                               .src2 = OperandMode::Mode::V,
-                                                               .src1 = OperandMode::Mode::X},
-                                                   true, DivByZeroProtect<std::modulus>::DivisorChecker>,
-                RvvIntegerInsts>(nullptr, "vrem.vx", ActionTags::EXECUTE_TAG));
+            pegasus::Action::createAction<&RvvIntegerInsts::viBinaryHandler_<
+                                              XLEN,
+                                              OperandMode{.dst = OperandMode::Mode::V,
+                                                          .src2 = OperandMode::Mode::V,
+                                                          .src1 = OperandMode::Mode::X},
+                                              true, DivByZeroProtect<std::modulus>::DivisorChecker>,
+                                          RvvIntegerInsts>(nullptr, "vrem.vx",
+                                                           ActionTags::EXECUTE_TAG));
 
         inst_handlers.emplace(
             "vwmul.vv",

--- a/core/observers/STFLogger.cpp
+++ b/core/observers/STFLogger.cpp
@@ -339,12 +339,12 @@ namespace pegasus
             }
         };
 
-        const auto & current_inst = *state->getCurrentInst();
         uint32_t opcode = 0;
         uint32_t opcode_size = 4;
 
         if (state->getCurrentInst() != nullptr)
         {
+            const auto & current_inst = *state->getCurrentInst();
             opcode = current_inst.getOpcode();
             opcode_size = current_inst.getOpcodeSize();
         }
@@ -355,6 +355,7 @@ namespace pegasus
 
         if (state->getCurrentInst() != nullptr)
         {
+            const auto & current_inst = *state->getCurrentInst();
             if (state->getXlen() == 32)
             {
                 writeInstRegRecord_<uint32_t>(state, get_stf_reg_type);

--- a/test/vector/CMakeLists.txt
+++ b/test/vector/CMakeLists.txt
@@ -10,6 +10,7 @@ file (CREATE_LINK ${PROJECT_SOURCE_DIR}/workloads                      ${CMAKE_C
 # Tests
 add_subdirectory(vcs)
 add_subdirectory(via)
+add_subdirectory(vid)
 add_subdirectory(vls)
 add_subdirectory(vm)
 add_subdirectory(vro)

--- a/test/vector/vid/CMakeLists.txt
+++ b/test/vector/vid/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(Vid_Test)
+
+file (CREATE_LINK ${PROJECT_SOURCE_DIR}/../../../arch                     ${CMAKE_CURRENT_BINARY_DIR}/arch SYMBOLIC)
+file (CREATE_LINK ${PROJECT_SOURCE_DIR}/../../../mavis/json               ${CMAKE_CURRENT_BINARY_DIR}/mavis_json SYMBOLIC)
+file (CREATE_LINK ${PROJECT_SOURCE_DIR}/../../../core/inst_handlers/rv64  ${CMAKE_CURRENT_BINARY_DIR}/rv64 SYMBOLIC)
+
+add_executable(Vid_test Vid_test.cpp)
+target_link_libraries(Vid_test pegasussim)
+
+pegasus_named_test(Vid_test_run Vid_test)

--- a/test/vector/vid/Vid_test.cpp
+++ b/test/vector/vid/Vid_test.cpp
@@ -25,9 +25,9 @@ class ViaInstructionTester : public PegasusInstructionTester
         state->getVectorConfig()->setLMUL(8); // vlmul = 1
         state->getVectorConfig()->setSEW(8);  // sew = 8
 
-        VLEN vs1_val = {1, 2, 2,  4,  5,  4,  7,  6};
+        VLEN vs1_val = {1, 2, 2, 4, 5, 4, 7, 6};
         VLEN vs2_val = {0, 2, 4, 12, 20, 20, 42, 42};
-        VLEN vs3_val = {0, 1, 2,  3,  4,  5,  6,  7};
+        VLEN vs3_val = {0, 1, 2, 3, 4, 5, 6, 7};
         WRITE_VEC_REG<VLEN>(state, vs1, vs1_val);
         WRITE_VEC_REG<VLEN>(state, vs2, vs2_val);
         opcode = vdivvvOp(vd, vs1, vs2, 1); // unmasked

--- a/test/vector/vid/Vid_test.cpp
+++ b/test/vector/vid/Vid_test.cpp
@@ -1,0 +1,234 @@
+#include "test/sim/InstructionTester.hpp"
+#include "core/VecElements.hpp"
+#include "sparta/utils/SpartaTester.hpp"
+#include "mavis/Mavis.h"
+
+class ViaInstructionTester : public PegasusInstructionTester
+{
+
+  public:
+    using VLEN = std::array<uint8_t, 8>;
+    using XLEN = uint64_t;
+
+    ViaInstructionTester() = default;
+
+    void testVdivvv1()
+    {
+        pegasus::PegasusState* state = getPegasusState();
+        const pegasus::Addr pc = 0x1000;
+        const uint32_t vd = 3, vs1 = 1, vs2 = 2;
+        uint32_t opcode;
+
+        state->getVectorConfig()->setVLEN(64);
+        state->getVectorConfig()->setVSTART(0);
+        state->getVectorConfig()->setVL(8);   // avl = 8
+        state->getVectorConfig()->setLMUL(8); // vlmul = 1
+        state->getVectorConfig()->setSEW(8);  // sew = 8
+
+        VLEN vs1_val = {1, 2, 2,  4,  5,  4,  7,  6};
+        VLEN vs2_val = {0, 2, 4, 12, 20, 20, 42, 42};
+        VLEN vs3_val = {0, 1, 2,  3,  4,  5,  6,  7};
+        WRITE_VEC_REG<VLEN>(state, vs1, vs1_val);
+        WRITE_VEC_REG<VLEN>(state, vs2, vs2_val);
+        opcode = vdivvvOp(vd, vs1, vs2, 1); // unmasked
+        std::cout << std::hex << opcode << std::dec << std::endl;
+        injectInstruction(pc, opcode);
+
+        auto vd_val = READ_VEC_REG<VLEN>(state, vd);
+        for (size_t i = 0; i < vd_val.size(); ++i)
+        {
+            EXPECT_EQUAL(int(vd_val[i]), int(vs3_val[i]));
+        }
+        const pegasus::PegasusState::SimState* sim_state = state->getSimState();
+        std::cout << sim_state->current_inst << std::endl;
+        EXPECT_EQUAL(sim_state->inst_count, 1);
+    }
+
+    void testVdivvv2()
+    {
+        pegasus::PegasusState* state = getPegasusState();
+        const pegasus::Addr pc = 0x1000;
+        uint32_t opcode;
+
+        state->getVectorConfig()->setVLEN(64);
+        state->getVectorConfig()->setVSTART(0);
+        state->getVectorConfig()->setVL(16);   // avl = 16
+        state->getVectorConfig()->setLMUL(16); // vlmul = 2
+        state->getVectorConfig()->setSEW(8);   // sew = 8
+
+        VLEN vs1_val = {0, 1, 2, 3, 4, 5, 6, 7};
+        VLEN vs2_val = {1, 2, 3, 4, 5, 6, 7, 8};
+        VLEN vs3_val = {9, 10, 11, 12, 13, 14, 15, 16};
+        VLEN vs4_val = {17, 18, 19, 20, 21, 22, 23, 24};
+        VLEN vs5_val = {9, 11, 13, 15, 17, 19, 21, 23};
+        VLEN vs6_val = {18, 20, 22, 24, 26, 28, 30, 32};
+        WRITE_VEC_REG<VLEN>(state, 1, vs1_val);
+        WRITE_VEC_REG<VLEN>(state, 2, vs2_val);
+        WRITE_VEC_REG<VLEN>(state, 3, vs3_val);
+        WRITE_VEC_REG<VLEN>(state, 4, vs4_val);
+        opcode = vdivvvOp(5, 1, 3, 1); // unmasked
+        injectInstruction(pc, opcode);
+
+        auto vd_val1 = READ_VEC_REG<VLEN>(state, 5);
+        for (size_t i = 0; i < vd_val1.size(); ++i)
+        {
+            EXPECT_EQUAL(vd_val1[i], vs5_val[i]);
+        }
+        auto vd_val2 = READ_VEC_REG<VLEN>(state, 6);
+        for (size_t i = 0; i < vd_val2.size(); ++i)
+        {
+            EXPECT_EQUAL(vd_val2[i], vs6_val[i]);
+        }
+        const pegasus::PegasusState::SimState* sim_state = state->getSimState();
+        std::cout << sim_state->current_inst << std::endl;
+        EXPECT_EQUAL(sim_state->inst_count, 2);
+    }
+
+    void testVdivvv3()
+    {
+        pegasus::PegasusState* state = getPegasusState();
+        const pegasus::Addr pc = 0x1000;
+        uint32_t opcode;
+
+        state->getVectorConfig()->setVLEN(64);
+        state->getVectorConfig()->setVSTART(2); // vstart = 2
+        state->getVectorConfig()->setVL(14);    // avl = 14
+        state->getVectorConfig()->setLMUL(16);  // vlmul = 2
+        state->getVectorConfig()->setSEW(8);    // sew = 8
+
+        VLEN rst_val = {0, 0, 0, 0, 0, 0, 0, 0};
+        VLEN vs1_val = {0, 1, 2, 3, 4, 5, 6, 7};
+        VLEN vs2_val = {1, 2, 3, 4, 5, 6, 7, 8};
+        VLEN vs3_val = {9, 10, 11, 12, 13, 14, 15, 16};
+        VLEN vs4_val = {17, 18, 19, 20, 21, 22, 23, 24};
+        VLEN vs5_val = {9, 11, 13, 15, 17, 19, 21, 23};
+        VLEN vs6_val = {18, 20, 22, 24, 26, 28, 30, 32};
+
+        WRITE_VEC_REG<VLEN>(state, 1, vs1_val);
+        WRITE_VEC_REG<VLEN>(state, 2, vs2_val);
+        WRITE_VEC_REG<VLEN>(state, 3, vs3_val);
+        WRITE_VEC_REG<VLEN>(state, 4, vs4_val);
+        WRITE_VEC_REG<VLEN>(state, 5, rst_val);
+        WRITE_VEC_REG<VLEN>(state, 6, rst_val);
+        opcode = vdivvvOp(5, 1, 3, 1); // unmasked
+        injectInstruction(pc, opcode);
+
+        auto vd_val1 = READ_VEC_REG<VLEN>(state, 5);
+        for (size_t i = 0; i < 2; ++i)
+        {
+            EXPECT_EQUAL(vd_val1[i], 0);
+        }
+        for (size_t i = 2; i < vd_val1.size(); ++i)
+        {
+            EXPECT_EQUAL(vd_val1[i], vs5_val[i]);
+        }
+
+        auto vd_val2 = READ_VEC_REG<VLEN>(state, 6);
+        for (size_t i = 0; i < 6; ++i)
+        {
+            EXPECT_EQUAL(vd_val2[i], vs6_val[i]);
+        }
+        for (size_t i = 6; i < vd_val2.size(); ++i)
+        {
+            EXPECT_EQUAL(vd_val2[i], 0);
+        }
+        const pegasus::PegasusState::SimState* sim_state = state->getSimState();
+        std::cout << sim_state->current_inst << std::endl;
+        EXPECT_EQUAL(sim_state->inst_count, 3);
+    }
+
+    void testVdivvv4()
+    {
+        pegasus::PegasusState* state = getPegasusState();
+        const pegasus::Addr pc = 0x1000;
+        uint32_t opcode;
+
+        state->getVectorConfig()->setVLEN(64);
+        state->getVectorConfig()->setVSTART(2); // vstart = 2
+        state->getVectorConfig()->setVL(14);    // avl = 14
+        state->getVectorConfig()->setLMUL(16);  // vlmul = 2
+        state->getVectorConfig()->setSEW(8);    // sew = 8
+
+        VLEN rst_val = {0, 0, 0, 0, 0, 0, 0, 0};
+        VLEN vs0_val = {0xF0, 0x0F, 0, 0, 0, 0, 0, 0}; // mask first and last 2
+        VLEN vs1_val = {0, 1, 2, 3, 4, 5, 6, 7};
+        VLEN vs2_val = {1, 2, 3, 4, 5, 6, 7, 8};
+        VLEN vs3_val = {9, 10, 11, 12, 13, 14, 15, 16};
+        VLEN vs4_val = {17, 18, 19, 20, 21, 22, 23, 24};
+        VLEN vs5_val = {9, 11, 13, 15, 17, 19, 21, 23};
+        VLEN vs6_val = {18, 20, 22, 24, 26, 28, 30, 32};
+
+        WRITE_VEC_REG<VLEN>(state, 0, vs0_val);
+        WRITE_VEC_REG<VLEN>(state, 1, vs1_val);
+        WRITE_VEC_REG<VLEN>(state, 2, vs2_val);
+        WRITE_VEC_REG<VLEN>(state, 3, vs3_val);
+        WRITE_VEC_REG<VLEN>(state, 4, vs4_val);
+        WRITE_VEC_REG<VLEN>(state, 5, rst_val);
+        WRITE_VEC_REG<VLEN>(state, 6, rst_val);
+        opcode = vdivvvOp(5, 1, 3, 0); // masked
+        injectInstruction(pc, opcode);
+
+        auto vd_val1 = READ_VEC_REG<VLEN>(state, 5);
+        for (size_t i = 0; i < 4; ++i)
+        {
+            EXPECT_EQUAL(vd_val1[i], 0);
+        }
+        for (size_t i = 4; i < vd_val1.size(); ++i)
+        {
+            EXPECT_EQUAL(vd_val1[i], vs5_val[i]);
+        }
+
+        auto vd_val2 = READ_VEC_REG<VLEN>(state, 6);
+        for (size_t i = 0; i < 4; ++i)
+        {
+            EXPECT_EQUAL(vd_val2[i], vs6_val[i]);
+        }
+        for (size_t i = 4; i < vd_val2.size(); ++i)
+        {
+            EXPECT_EQUAL(vd_val2[i], 0);
+        }
+        const pegasus::PegasusState::SimState* sim_state = state->getSimState();
+        std::cout << sim_state->current_inst << std::endl;
+        EXPECT_EQUAL(sim_state->inst_count, 4);
+    }
+
+    uint32_t vdivvvOp(uint8_t rd, uint8_t rs1, uint8_t rs2, uint8_t vm)
+    {
+        uint32_t opcode = 0;
+        uint32_t offset = 0;
+        opcode |= 0x57 << offset; // opcode
+        offset += 7;
+        opcode |= rd << offset; // rd
+        offset += 6;
+        opcode |= 1 << offset;
+        offset += 2;
+        opcode |= rs1 << offset; // rs1
+        offset += 5;
+        opcode |= rs2 << offset; // rs2
+        offset += 5;
+        opcode |= vm << offset; // vm
+        offset += 1;
+        opcode |= 0 << offset;
+        offset += 5;
+        opcode |= 1 << offset;
+        offset += 1;
+        EXPECT_EQUAL(offset, 32);
+        return opcode;
+    }
+
+  private:
+    pegasus::PegasusInst::PtrType instPtr_ = nullptr;
+};
+
+int main()
+{
+    ViaInstructionTester Via_tester;
+
+    Via_tester.testVdivvv1();
+    // Via_tester.testVdivvv2();
+    // Via_tester.testVdivvv3();
+    // Via_tester.testVdivvv4();
+
+    REPORT_ERROR;
+    return ERROR_CODE;
+}


### PR DESCRIPTION
On x86 machines, a divide by zero will fault.  On ARM, this does not happen.  This protects the simulator from the fault