### PR TITLE
Various STF tracing bug fixes

### DIFF
--- a/core/Fetch.cpp
+++ b/core/Fetch.cpp
@@ -142,6 +142,8 @@ namespace pegasus
             }
         }
 
+        ILOG("Fetched opcode: " << HEX8(opcode));
+
         // Decode instruction with Mavis
         PegasusInstPtr inst = nullptr;
         try

--- a/core/observers/STFLogger.cpp
+++ b/core/observers/STFLogger.cpp
@@ -12,7 +12,8 @@ namespace pegasus
                          PegasusState* state, std::optional<uint32_t> opcode_trigger) :
         Observer((reg_width == 32) ? ObserverMode::RV32 : ObserverMode::RV64),
         filename_(filename),
-        opcode_trigger_(opcode_trigger)
+        opcode_trigger_(opcode_trigger),
+        vector_enabled_(state->isExtensionEnabled("v"))
     {
         startSTFTrace_(inital_pc, filename, state);
     }
@@ -53,7 +54,9 @@ namespace pegasus
 
         const auto & isa = state->getISAString();
 
-        stf_writer_.setVLen(state->getVectorConfig()->getVLEN());
+        if (vector_enabled_) {
+            stf_writer_.setVLen(state->getVectorConfig()->getVLEN());
+        }
         stf_writer_.setISA(stf::ISA::RISCV);
         stf_writer_.setISAExtendedInfo(isa);
         stf_writer_.setHeaderPC(inital_pc);
@@ -423,6 +426,12 @@ namespace pegasus
         }
     }
 
+    template <typename Var, typename... Val>
+    constexpr bool isOneOf(Var && var, Val &&... val)
+    {
+        return ((var == val) || ...);
+    }
+
     template <typename XLEN> void STFLogger::recordRegState_(PegasusState* state)
     {
         // Recording int registers
@@ -439,18 +448,30 @@ namespace pegasus
                                               stf::Registers::STF_REG_OPERAND_TYPE::REG_STATE,
                                               READ_FP_REG<XLEN>(state, i));
         }
-        // Recording vector registers
-        for (uint32_t i = 0; i < state->getVecRegisterSet()->getNumRegisters(); ++i)
+
+        if (vector_enabled_)
         {
-            stf_writer_ << stf::InstRegRecord(
-                i, stf::Registers::STF_REG_TYPE::VECTOR,
-                stf::Registers::STF_REG_OPERAND_TYPE::REG_STATE,
-                readVectorRegister_(state, RegId{RegType::VECTOR, i, "V" + std::to_string(i)}));
+            // Recording vector registers
+            for (uint32_t i = 0; i < state->getVecRegisterSet()->getNumRegisters(); ++i)
+            {
+                stf_writer_ << stf::InstRegRecord(
+                    i, stf::Registers::STF_REG_TYPE::VECTOR,
+                    stf::Registers::STF_REG_OPERAND_TYPE::REG_STATE,
+                    readVectorRegister_(state, RegId{RegType::VECTOR, i, "V" + std::to_string(i)}));
+            }
         }
+
         // Recording csr Registers
         auto csr_rset = state->getCsrRegisterSet();
         for (size_t i = 0; i < csr_rset->getNumRegisters(); ++i)
         {
+            if (false == vector_enabled_)
+            {
+                if (isOneOf(i, VL, VTYPE, VLENB)) {
+                    continue;
+                }
+            }
+
             if (auto reg = csr_rset->getRegister(i))
             {
                 stf_writer_ << stf::InstRegRecord(i, stf::Registers::STF_REG_TYPE::CSR,

--- a/core/observers/STFLogger.cpp
+++ b/core/observers/STFLogger.cpp
@@ -27,9 +27,7 @@ namespace pegasus
         }
         catch (std::exception & e)
         {
-            std::cerr
-                << "Issues with the STF Filename: " << e.what()
-                << std::endl;
+            std::cerr << "Issues with the STF Filename: " << e.what() << std::endl;
             throw;
         }
 
@@ -54,7 +52,8 @@ namespace pegasus
 
         const auto & isa = state->getISAString();
 
-        if (vector_enabled_) {
+        if (vector_enabled_)
+        {
             stf_writer_.setVLen(state->getVectorConfig()->getVLEN());
         }
         stf_writer_.setISA(stf::ISA::RISCV);
@@ -80,13 +79,13 @@ namespace pegasus
             if (src_reg.reg_id.reg_type != RegType::VECTOR)
             {
                 const bool is_x0 =
-                    (src_reg.reg_id.reg_type == RegType::INTEGER) &&
-                    (src_reg.reg_id.reg_num == 0);
+                    (src_reg.reg_id.reg_type == RegType::INTEGER) && (src_reg.reg_id.reg_num == 0);
                 if (not is_x0)
                 {
-                    stf_writer_ << stf::InstRegRecord(src_reg.reg_id.reg_num, stf_reg_type,
-                                                      stf::Registers::STF_REG_OPERAND_TYPE::REG_SOURCE,
-                                                      src_reg.getRegValue<XLEN>());
+                    stf_writer_ << stf::InstRegRecord(
+                        src_reg.reg_id.reg_num, stf_reg_type,
+                        stf::Registers::STF_REG_OPERAND_TYPE::REG_SOURCE,
+                        src_reg.getRegValue<XLEN>());
                 }
             }
             else
@@ -432,8 +431,7 @@ namespace pegasus
         }
     }
 
-    template <typename Var, typename... Val>
-    constexpr bool isOneOf(Var && var, Val &&... val)
+    template <typename Var, typename... Val> constexpr bool isOneOf(Var && var, Val &&... val)
     {
         return ((var == val) || ...);
     }
@@ -471,11 +469,9 @@ namespace pegasus
         auto csr_rset = state->getCsrRegisterSet();
         for (size_t i = 0; i < csr_rset->getNumRegisters(); ++i)
         {
-            if (false == vector_enabled_)
+            if (false == vector_enabled_ and isOneOf(i, VL, VTYPE, VLENB))
             {
-                if (isOneOf(i, VL, VTYPE, VLENB)) {
-                    continue;
-                }
+                continue;
             }
 
             if (auto reg = csr_rset->getRegister(i))

--- a/core/observers/STFLogger.cpp
+++ b/core/observers/STFLogger.cpp
@@ -25,10 +25,10 @@ namespace pegasus
         {
             stf_writer_.open(filename);
         }
-        catch (...)
+        catch (std::exception & e)
         {
             std::cerr
-                << "STF Filename formatted incorrectly: does the file have a STF file extension"
+                << "Issues with the STF Filename: " << e.what()
                 << std::endl;
             throw;
         }
@@ -79,9 +79,15 @@ namespace pegasus
             const auto stf_reg_type = get_stf_reg_type(src_reg.reg_id.reg_type);
             if (src_reg.reg_id.reg_type != RegType::VECTOR)
             {
-                stf_writer_ << stf::InstRegRecord(src_reg.reg_id.reg_num, stf_reg_type,
-                                                  stf::Registers::STF_REG_OPERAND_TYPE::REG_SOURCE,
-                                                  src_reg.getRegValue<XLEN>());
+                const bool is_x0 =
+                    (src_reg.reg_id.reg_type == RegType::INTEGER) &&
+                    (src_reg.reg_id.reg_num == 0);
+                if (not is_x0)
+                {
+                    stf_writer_ << stf::InstRegRecord(src_reg.reg_id.reg_num, stf_reg_type,
+                                                      stf::Registers::STF_REG_OPERAND_TYPE::REG_SOURCE,
+                                                      src_reg.getRegValue<XLEN>());
+                }
             }
             else
             {

--- a/core/observers/STFLogger.hpp
+++ b/core/observers/STFLogger.hpp
@@ -43,6 +43,8 @@ namespace pegasus
 
         const std::optional<uint32_t> opcode_trigger_;
 
+        const bool vector_enabled_;
+
         std::string current_symbol_;
     };
 } // namespace pegasus

--- a/system/PegasusSystem.cpp
+++ b/system/PegasusSystem.cpp
@@ -397,24 +397,7 @@ namespace pegasus
 
     void PegasusSystem::registerMemoryCallbacks(Observer* observer)
     {
-        using BMOIfNode = sparta::memory::BlockingMemoryIFNode;
-        for (const auto & n : tree_nodes_)
-        {
-            if (auto bm_if_node = dynamic_cast<BMOIfNode*>(n.get()))
-            {
-                observer->registerReadWriteMemCallbacks(bm_if_node);
-            }
-        }
-
-        // Register callbacks to system memory
-        auto iter = std::find_if(tree_nodes_.begin(), tree_nodes_.end(),
-                                 [this](const std::unique_ptr<sparta::TreeNode> & tnode)
-                                 { return tnode.get() == memory_map_.get(); });
-
-        if (iter != tree_nodes_.end())
-        {
-            observer->registerReadWriteMemCallbacks(memory_map_.get());
-        }
+        observer->registerReadWriteMemCallbacks(memory_map_.get());
     }
 
     void PegasusSystem::enableEOTPassFailMode()


### PR DESCRIPTION
- If vector is not enabled, do not record vector information in the trace
- Do not record x0
- Record all memory accesses to the map, not just main memory components