### PR TITLE
Add support for START/STOP Trace Markers

### DIFF
--- a/core/PegasusState.cpp
+++ b/core/PegasusState.cpp
@@ -106,6 +106,7 @@ namespace pegasus
         ulimit_stack_size_(p->ulimit_stack_size),
         stf_filename_(p->stf_filename),
         stf_opcode_trigger_(p->stf_opcode_trigger),
+        stf_trace_points_(p->stf_trace_points),
         validation_stf_filename_(p->validate_with_stf),
         validate_trace_begin_(p->validate_trace_begin),
         validate_inst_begin_(p->validate_inst_begin),
@@ -371,8 +372,8 @@ namespace pegasus
 
         if (!stf_filename_.empty())
         {
-            addObserver(
-                std::make_unique<STFLogger>(xlen_, pc_, stf_filename_, this, stf_opcode_trigger_));
+            addObserver(std::make_unique<STFLogger>(xlen_, pc_, stf_filename_, this,
+                                                    stf_opcode_trigger_, stf_trace_points_));
         }
 
         if (!validation_stf_filename_.empty())

--- a/core/PegasusState.hpp
+++ b/core/PegasusState.hpp
@@ -96,6 +96,9 @@ namespace pegasus
                       "STF Trace file name (when not given, STF tracing is disabled)")
             PARAMETER(uint32_t, stf_opcode_trigger, std::numeric_limits<uint32_t>::max(),
                       "Break up STF trace generation using the given opcode as the trigger")
+            PARAMETER(
+                bool, stf_trace_points, false,
+                "Break up STF tracing using START/STOP trace markers (xor x0,x0,x0/xor x0,x1,x1)")
             PARAMETER(std::string, validate_with_stf, "",
                       "STF Trace file name (when not given, STF tracing is disabled)")
             PARAMETER(uint64_t, validate_trace_begin, 1,
@@ -460,6 +463,7 @@ namespace pegasus
         // STF Trace Filename
         const std::string stf_filename_;
         const uint32_t stf_opcode_trigger_;
+        const bool stf_trace_points_;
         const std::string validation_stf_filename_;
         const uint64_t validate_trace_begin_;
         const uint64_t validate_inst_begin_;

--- a/core/observers/Observer.cpp
+++ b/core/observers/Observer.cpp
@@ -10,6 +10,9 @@ namespace pegasus
     void Observer::preExecute(PegasusState* state)
     {
         reset_();
+
+        enableObserver_(state);
+
         inspectInitialState_(state);
 
         // Subclass impl
@@ -37,6 +40,11 @@ namespace pegasus
 
     void Observer::postExecute(PegasusState* state)
     {
+        if (not enabled_)
+        {
+            return;
+        }
+
         // Get final value of destination registers
         PegasusInstPtr inst = state->getCurrentInst();
 
@@ -78,6 +86,11 @@ namespace pegasus
 
     void Observer::inspectInitialState_(PegasusState* state)
     {
+        if (not enabled_)
+        {
+            return;
+        }
+
         pc_ = state->getPc();
         priv_mode_ = state->getPrivMode();
         virtual_mode_ = state->getVirtualMode();

--- a/core/observers/Observer.hpp
+++ b/core/observers/Observer.hpp
@@ -279,6 +279,7 @@ namespace pegasus
         PrivMode priv_mode_;
         bool virtual_mode_;
         uint64_t opcode_;
+        bool enabled_ = true; // Sometimes the observer is disabled, like tracing on/off
 
         // Mavis pointer for getting the disassembly string
         mavis::OpcodeInfo::PtrType opcode_info_;
@@ -327,6 +328,9 @@ namespace pegasus
         sparta::utils::ValidValue<ObserverMode> arch_;
 
         void inspectInitialState_(PegasusState* state);
+
+        // Are the pre-conditions suited to enable the observer
+        virtual void enableObserver_(PegasusState*) {}
 
         virtual void preExecute_(PegasusState*) {}
 

--- a/core/observers/STFLogger.cpp
+++ b/core/observers/STFLogger.cpp
@@ -9,18 +9,29 @@
 namespace pegasus
 {
     STFLogger::STFLogger(const uint32_t reg_width, uint64_t inital_pc, const std::string & filename,
-                         PegasusState* state, std::optional<uint32_t> opcode_trigger) :
+                         PegasusState* state, std::optional<uint32_t> opcode_trigger,
+                         bool use_trace_points) :
         Observer((reg_width == 32) ? ObserverMode::RV32 : ObserverMode::RV64),
         filename_(filename),
         opcode_trigger_(opcode_trigger),
+        use_trace_points_(use_trace_points),
         vector_enabled_(state->isExtensionEnabled("v"))
     {
-        startSTFTrace_(inital_pc, filename, state);
+        if (false == use_trace_points_)
+        {
+            // Immediate turn on tracing
+            startSTFTrace_(inital_pc, filename, state);
+        }
+        else
+        {
+            enabled_ = false;
+        }
     }
 
     void STFLogger::startSTFTrace_(uint64_t inital_pc, const std::string & filename,
                                    PegasusState* state)
     {
+        enabled_ = true;
         try
         {
             stf_writer_.open(filename);
@@ -308,6 +319,43 @@ namespace pegasus
             static_cast<uint64_t>(READ_CSR_REG<XLEN>(state, MTVEC)));
     }
 
+    std::string STFLogger::genTraceName_()
+    {
+        // Find the position of the .zstf or .stf
+        const size_t dotPos = filename_.find_last_of('.');
+        return filename_.substr(0, dotPos) + current_symbol_ + "_"
+               + std::to_string(++trace_instance_) + filename_.substr(dotPos);
+    }
+
+    void STFLogger::enableObserver_(PegasusState* state)
+    {
+        const PegasusInstPtr & inst = state->getCurrentInst();
+        if (inst)
+        {
+            if (not enabled_)
+            {
+                // See if we should enable tracing
+                sparta_assert(
+                    use_trace_points_,
+                    "Somehow the STF logger was not enabled, but trace points aren't used? "
+                        << "How do we turn on the STF logger?");
+                if (inst->getOpcode() == STF_START_TRACE)
+                {
+                    startSTFTrace_(state->getNextPc(), genTraceName_(), state);
+                    enabled_ = true;
+                }
+            }
+            else
+            {
+                if (inst->getOpcode() == STF_STOP_TRACE)
+                {
+                    stf_writer_.close();
+                    enabled_ = false;
+                }
+            }
+        }
+    }
+
     void STFLogger::postExecute_(PegasusState* state)
     {
         for (const auto & mem_write : mem_writes_)
@@ -421,13 +469,7 @@ namespace pegasus
             // Close current trace, open a new one
             stf_writer_.close();
 
-            // Find the position of the .zstf or .stf
-            const size_t dotPos = filename_.find_last_of('.');
-            const auto new_trace_file_name = filename_.substr(0, dotPos) + current_symbol_ + "_"
-                                             + std::to_string(++trace_instance_)
-                                             + filename_.substr(dotPos);
-
-            startSTFTrace_(state->getNextPc(), new_trace_file_name, state);
+            startSTFTrace_(state->getNextPc(), genTraceName_(), state);
         }
     }
 

--- a/core/observers/STFLogger.hpp
+++ b/core/observers/STFLogger.hpp
@@ -20,13 +20,25 @@ namespace pegasus
          * \param filename Name of the file the trace will be written to
          * \param state PegasusState used to populate initial register values
          * \param opcode_trigger The opcode to start a new STF trace file
+         * \param use_trace_points If true, the STF tracer will start
+         *                         tracing when it sees the xor x0,
+         *                         x0, x0 pattern and stop when it
+         *                         sees xor x0, x1, x1 pattern
+         *
+         * If the tracer sees multiple start/stop trace markers, it
+         * will create multiple out files, with an incrementing number
          */
         STFLogger(const uint32_t reg_width, uint64_t initial_pc, const std::string & filename,
-                  PegasusState* state, std::optional<uint32_t> opcode_trigger);
+                  PegasusState* state, std::optional<uint32_t> opcode_trigger,
+                  bool use_trace_points);
+
+        static constexpr uint32_t STF_START_TRACE = 0x00004033;
+        static constexpr uint32_t STF_STOP_TRACE = 0x0010c033;
 
       private:
         stf::STFWriter stf_writer_;
-        void postExecute_(PegasusState* state) override;
+        void postExecute_(PegasusState*) override;
+        void enableObserver_(PegasusState* state) override;
 
         template <typename XLEN> void recordRegState_(PegasusState* state);
 
@@ -37,11 +49,15 @@ namespace pegasus
 
         void startSTFTrace_(uint64_t inital_pc, const std::string & filename, PegasusState* state);
 
+        std::string genTraceName_();
+
         uint32_t trace_instance_ = 0;
 
         const std::string filename_;
 
         const std::optional<uint32_t> opcode_trigger_;
+
+        const bool use_trace_points_;
 
         const bool vector_enabled_;
 

--- a/system/PegasusSystem.cpp
+++ b/system/PegasusSystem.cpp
@@ -87,8 +87,8 @@ namespace pegasus
                 // ELFIO::Elf64_Addr addr;
                 Addr addr = 0;
                 ELFIO::Elf_Xword size = 0;
-                unsigned char bind;
-                unsigned char type;
+                unsigned char bind = 0;
+                unsigned char type = 0;
                 ELFIO::Elf_Half section;
                 unsigned char other;
                 symbols.get_symbol(symbol_id, name, addr, size, bind, type, section, other);

--- a/test/elfs/linux/GNUmakefile
+++ b/test/elfs/linux/GNUmakefile
@@ -1,5 +1,5 @@
 
-LINUX_TESTS ?= dhry syscall_test fstatat_test threading memcpy
+LINUX_TESTS ?= dhry syscall_test fstatat_test threading
 
 include ../common.mk
 

--- a/test/elfs/linux/GNUmakefile
+++ b/test/elfs/linux/GNUmakefile
@@ -1,5 +1,5 @@
 
-LINUX_TESTS ?= dhry syscall_test fstatat_test threading
+LINUX_TESTS ?= dhry syscall_test fstatat_test threading memcpy
 
 include ../common.mk
 


### PR DESCRIPTION
Uses the nop pattern `xor zero, zero, zero` to start and `xor zero, 1, 1` to stop.

Also added the concept of enabling/disabling the observer.  However, _removing_ the observer callbacks would
be preferential.  

Tens tests: PASS RATE: 100.00% (14255/14255)
RISC-V tests: PASS RATE: 100.00% (648/648)
